### PR TITLE
fix: H1 peek double-read, plaintext H2 session isolation, metrics hot-path

### DIFF
--- a/server/handlers/http.rs
+++ b/server/handlers/http.rs
@@ -194,16 +194,19 @@ async fn handle_plaintext_h2_connection(
     use hyper::service::service_fn;
     use hyper::{Request, Response};
     use hyper_util::rt::TokioIo;
-    use std::sync::OnceLock;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
     debug!("plaintext H2 detected, using L7 proxy");
     let src_addr = peer_addr.ip().to_string();
     let src_port = peer_addr.port();
     let h2_single_authority = state.config.server.h2_single_authority;
-    let first_authority: Arc<OnceLock<String>> = Arc::new(OnceLock::new());
+    let first_authority: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
     #[allow(clippy::type_complexity)]
-    let route_cache: Arc<OnceLock<Option<(Arc<str>, Arc<str>)>>> = Arc::new(OnceLock::new());
-    let sender_cache: Arc<OnceLock<(quinn::Connection, tunnel_lib::H2Sender)>> =
-        Arc::new(OnceLock::new());
+    let route_cache: Arc<Mutex<HashMap<String, Option<(Arc<str>, Arc<str>)>>>> =
+        Arc::new(Mutex::new(HashMap::new()));
+    #[allow(clippy::type_complexity)]
+    let sender_cache: Arc<Mutex<HashMap<(Arc<str>, Arc<str>), (quinn::Connection, tunnel_lib::H2Sender)>>> =
+        Arc::new(Mutex::new(HashMap::new()));
     let service = service_fn(move |req: Request<hyper::body::Incoming>| {
         let state = state.clone();
         let first_authority = first_authority.clone();
@@ -232,21 +235,29 @@ async fn handle_plaintext_h2_connection(
             };
             let route_host = host.split(':').next().unwrap_or(&host).to_ascii_lowercase();
             if h2_single_authority {
-                let pinned = first_authority.get_or_init(|| route_host.clone());
-                if pinned != &route_host {
-                    return Ok(Response::builder()
-                        .status(421)
-                        .body(
-                            Full::new(bytes::Bytes::from("Misdirected Request"))
-                                .map_err(|_| unreachable!())
-                                .boxed_unsync(),
-                        )
-                        .unwrap());
+                let mut fa = first_authority.lock().unwrap();
+                match fa.as_ref() {
+                    None => *fa = Some(route_host.clone()),
+                    Some(pinned) if pinned != &route_host => {
+                        return Ok(Response::builder()
+                            .status(421)
+                            .body(
+                                Full::new(bytes::Bytes::from("Misdirected Request"))
+                                    .map_err(|_| unreachable!())
+                                    .boxed_unsync(),
+                            )
+                            .unwrap());
+                    }
+                    Some(_) => {}
                 }
             }
-            let route = route_cache
-                .get_or_init(|| lookup_route(&state, port, &route_host))
-                .clone();
+            let route = {
+                let mut cache = route_cache.lock().unwrap();
+                cache
+                    .entry(route_host.clone())
+                    .or_insert_with(|| lookup_route(&state, port, &route_host))
+                    .clone()
+            };
             let (group_id, proxy_name) = match route {
                 Some(r) => r,
                 None => {
@@ -262,13 +273,30 @@ async fn handle_plaintext_h2_connection(
                     );
                 }
             };
-            let (client_conn, h2_sender) = sender_cache.get_or_init(|| {
-                let selected = state
-                    .registry
-                    .select_client_for_group(&group_id)
-                    .expect("no client for group");
-                (selected.conn, tunnel_lib::new_h2_sender())
-            });
+            let cache_key = (group_id.clone(), proxy_name.clone());
+            let (client_conn, h2_sender) = {
+                let mut guard = sender_cache.lock().unwrap();
+                if !guard.contains_key(&cache_key) {
+                    if let Some(selected) =
+                        state.registry.select_client_for_group(&group_id)
+                    {
+                        guard.insert(cache_key.clone(), (selected.conn, tunnel_lib::new_h2_sender()));
+                    }
+                }
+                match guard.get(&cache_key) {
+                    Some(pair) => (pair.0.clone(), pair.1.clone()),
+                    None => {
+                        return Ok(Response::builder()
+                            .status(502)
+                            .body(
+                                Full::new(bytes::Bytes::from("No client available"))
+                                    .map_err(|_| unreachable!())
+                                    .boxed_unsync(),
+                            )
+                            .unwrap());
+                    }
+                }
+            };
             let (parts, body) = req.into_parts();
             debug!(
                 "L7 Proxy (plaintext H2): {} {} -> {}",
@@ -283,10 +311,11 @@ async fn handle_plaintext_h2_connection(
             };
             let boxed_body = body.map_err(std::io::Error::other).boxed_unsync();
             let upstream_req = Request::from_parts(parts, boxed_body);
-            match tunnel_lib::forward_h2_request(client_conn, h2_sender, routing_info, upstream_req).await {
+            match tunnel_lib::forward_h2_request(&client_conn, &h2_sender, routing_info, upstream_req).await {
                 Ok(resp) => Ok::<_, hyper::Error>(resp),
                 Err(e) => {
                     tracing::error!("L7 Proxy upstream error: {}", e);
+                    sender_cache.lock().unwrap().remove(&cache_key);
                     Ok(Response::builder()
                         .status(502)
                         .body(
@@ -308,14 +337,13 @@ async fn handle_plaintext_h2_connection(
 }
 async fn handle_plaintext_h1_connection(
     state: Arc<ServerState>,
-    mut stream: TcpStream,
+    stream: TcpStream,
     host: String,
     protocol: String,
     peer_addr: std::net::SocketAddr,
     initial_data: &[u8],
     port: u16,
 ) -> Result<()> {
-    use tokio::io::AsyncReadExt;
     debug!(host = %host, protocol = %protocol, "plaintext H1/WS, using byte-level forwarding");
     let (group_id, proxy_name) = lookup_route(&state, port, &host)
         .ok_or_else(|| anyhow::anyhow!("no route for host: {}", host))?;
@@ -323,8 +351,6 @@ async fn handle_plaintext_h1_connection(
         .registry
         .select_client_for_group(&group_id)
         .ok_or_else(|| anyhow::anyhow!("no client for group: {}", group_id))?;
-    let mut discard = vec![0u8; initial_data.len()];
-    stream.read_exact(&mut discard).await?;
     let routing_info = tunnel_lib::RoutingInfo {
         proxy_name: proxy_name.to_string(),
         src_addr: peer_addr.ip().to_string(),
@@ -351,11 +377,11 @@ async fn handle_plaintext_h1_connection(
         }
     };
     tunnel_lib::send_routing_info(&mut send, &routing_info).await?;
-    proxy::forward_with_initial_data(
+    let prefixed = tunnel_lib::PrefixedReadWrite::new(stream, bytes::Bytes::copy_from_slice(initial_data));
+    proxy::forward_prefixed(
         send,
         recv,
-        stream,
-        initial_data,
+        prefixed,
         state.proxy_buffer_params.relay_buf_size,
     )
     .await

--- a/server/metrics.rs
+++ b/server/metrics.rs
@@ -3,7 +3,6 @@ use prometheus::{
     Encoder, Gauge, Histogram, HistogramOpts, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
     Opts, Registry, TextEncoder,
 };
-use std::sync::Arc;
 lazy_static! {
     pub static ref REGISTRY: Registry = Registry::new();
     pub static ref ACTIVE_QUIC_CONNECTIONS: IntGauge = IntGauge::new(
@@ -80,12 +79,9 @@ lazy_static! {
         "open_bi timeout ratio = timeout_total / open_bi_total"
     )
     .unwrap();
-    pub static ref OPEN_BI_INFLIGHT_PER_CONN: IntGaugeVec = IntGaugeVec::new(
-        Opts::new(
-            "duotunnel_open_bi_inflight_per_conn",
-            "In-flight streams per selected client connection"
-        ),
-        &["conn_id"]
+    pub static ref OPEN_BI_INFLIGHT: IntGauge = IntGauge::new(
+        "duotunnel_open_bi_inflight",
+        "Currently in-flight open_bi calls"
     )
     .unwrap();
 }
@@ -113,11 +109,12 @@ pub fn init() {
     REGISTRY.register(Box::new(OPEN_BI_TOTAL.clone())).ok();
     REGISTRY.register(Box::new(OPEN_BI_TIMEOUT_TOTAL.clone())).ok();
     REGISTRY.register(Box::new(OPEN_BI_TIMEOUT_RATIO.clone())).ok();
-    REGISTRY
-        .register(Box::new(OPEN_BI_INFLIGHT_PER_CONN.clone()))
-        .ok();
+    REGISTRY.register(Box::new(OPEN_BI_INFLIGHT.clone())).ok();
 }
 pub fn encode() -> String {
+    let total = OPEN_BI_TOTAL.get() as f64;
+    let timeout = OPEN_BI_TIMEOUT_TOTAL.get() as f64;
+    OPEN_BI_TIMEOUT_RATIO.set(if total > 0.0 { timeout / total } else { 0.0 });
     let encoder = TextEncoder::new();
     let metric_families = REGISTRY.gather();
     let mut buffer = Vec::new();
@@ -157,34 +154,18 @@ pub fn connection_rejected(conn_type: &str) {
     CONNECTIONS_REJECTED.with_label_values(&[conn_type]).inc();
 }
 
-fn refresh_open_bi_timeout_ratio() {
-    let total = OPEN_BI_TOTAL.get() as f64;
-    let timeout = OPEN_BI_TIMEOUT_TOTAL.get() as f64;
-    let ratio = if total > 0.0 { timeout / total } else { 0.0 };
-    OPEN_BI_TIMEOUT_RATIO.set(ratio);
-}
-
-pub struct OpenBiInflightGuard {
-    conn_id: Arc<str>,
-}
+pub struct OpenBiInflightGuard;
 
 impl Drop for OpenBiInflightGuard {
     fn drop(&mut self) {
-        OPEN_BI_INFLIGHT_PER_CONN
-            .with_label_values(&[self.conn_id.as_ref()])
-            .dec();
+        OPEN_BI_INFLIGHT.dec();
     }
 }
 
-pub fn open_bi_begin(conn_id: &Arc<str>) -> OpenBiInflightGuard {
+pub fn open_bi_begin(_conn_id: &std::sync::Arc<str>) -> OpenBiInflightGuard {
     OPEN_BI_TOTAL.inc();
-    OPEN_BI_INFLIGHT_PER_CONN
-        .with_label_values(&[conn_id.as_ref()])
-        .inc();
-    refresh_open_bi_timeout_ratio();
-    OpenBiInflightGuard {
-        conn_id: Arc::clone(conn_id),
-    }
+    OPEN_BI_INFLIGHT.inc();
+    OpenBiInflightGuard
 }
 
 pub fn open_bi_observe_wait_ms(wait_ms: f64) {
@@ -193,5 +174,4 @@ pub fn open_bi_observe_wait_ms(wait_ms: f64) {
 
 pub fn open_bi_timeout() {
     OPEN_BI_TIMEOUT_TOTAL.inc();
-    refresh_open_bi_timeout_ratio();
 }

--- a/tunnel-lib/src/proxy/base.rs
+++ b/tunnel-lib/src/proxy/base.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use quinn::{RecvStream, SendStream};
-use tokio::io::{AsyncWriteExt, BufReader};
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
 
 pub async fn forward_to_client(
@@ -23,6 +23,35 @@ pub async fn forward_to_client(
         Ok::<_, std::io::Error>(bytes)
     };
     let (r1, r2) = tokio::join!(quic_to_tcp, tcp_to_quic);
+    match (r1, r2) {
+        (Ok(_), Ok(_)) => Ok(()),
+        (Err(e), _) | (_, Err(e)) => Err(e.into()),
+    }
+}
+
+pub async fn forward_prefixed<S>(
+    mut send: SendStream,
+    recv: RecvStream,
+    external_stream: S,
+    relay_buf_size: usize,
+) -> Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let (ext_read, mut ext_write) = tokio::io::split(external_stream);
+    let mut quic_recv = BufReader::with_capacity(relay_buf_size, recv);
+    let mut ext_read = BufReader::with_capacity(relay_buf_size, ext_read);
+    let quic_to_ext = async {
+        let bytes = tokio::io::copy_buf(&mut quic_recv, &mut ext_write).await?;
+        let _ = ext_write.shutdown().await;
+        Ok::<_, std::io::Error>(bytes)
+    };
+    let ext_to_quic = async {
+        let bytes = tokio::io::copy_buf(&mut ext_read, &mut send).await?;
+        let _ = send.finish();
+        Ok::<_, std::io::Error>(bytes)
+    };
+    let (r1, r2) = tokio::join!(quic_to_ext, ext_to_quic);
     match (r1, r2) {
         (Ok(_), Ok(_)) => Ok(()),
         (Err(e), _) | (_, Err(e)) => Err(e.into()),

--- a/tunnel-lib/src/proxy/mod.rs
+++ b/tunnel-lib/src/proxy/mod.rs
@@ -7,7 +7,7 @@ pub mod http;
 pub mod peers;
 pub mod tcp;
 pub mod upstream;
-pub use base::{forward_to_client, forward_with_initial_data};
+pub use base::{forward_prefixed, forward_to_client, forward_with_initial_data};
 pub use buffer_params::ProxyBufferParams;
 pub use h2_proxy::{forward_h2_request, new_h2_sender, H2Sender};
 pub use upstream::UpstreamGroup;


### PR DESCRIPTION
## Summary

- **H1/WS relay**: remove `read_exact` discard after `peek`; wrap `TcpStream` in `PrefixedReadWrite` and relay via new `forward_prefixed()`, eliminating one allocation and one syscall per connection
- **Plaintext H2 correctness**: replace `OnceLock` caches with `Mutex<HashMap>` — `route_cache` keyed per authority, `sender_cache` keyed by `(group_id, proxy_name)`; prevents cross-authority and cross-proxy QUIC session reuse on a single ingress H2 connection; sender entry is evicted on upstream error so the next request re-selects a live client
- **Metrics**: replace UUID-labeled `OPEN_BI_INFLIGHT_PER_CONN` gauge with a plain `OPEN_BI_INFLIGHT` IntGauge; move timeout ratio calculation to `encode()` (scrape time) instead of recomputing on every `open_bi` call
- **base.rs**: preserve `TcpStream::into_split()` fast path in `forward_to_client()`; add `forward_prefixed<S>` for generic prefixed streams so the TCP hot path has no added lock overhead