### PR TITLE
refactor/runtime and proxy

### DIFF
--- a/server/control_client.rs
+++ b/server/control_client.rs
@@ -23,27 +23,57 @@ use crate::config::{
     TunnelManagement, UpstreamDef, VhostRule,
 };
 use crate::local_auth::CacheEntry;
+use crate::service::BackgroundService;
 use crate::{build_routing_snapshot, ServerState};
+use tokio_util::sync::CancellationToken;
 
-/// Spawn the control client watch loop as a background task.
-pub fn spawn_control_client(ctld_addr: SocketAddr, state: Arc<ServerState>) {
-    crate::spawn_task(async move {
-        let mut backoff = Duration::from_secs(1);
-        let mut last_version: u64 = 0;
-        loop {
-            match connect_and_watch(ctld_addr, &state, last_version).await {
-                Ok(version) => {
-                    last_version = version;
-                    backoff = Duration::from_secs(1);
-                }
-                Err(e) => {
-                    error!(error = %e, addr = %ctld_addr, "ctld watch connection failed");
-                    tokio::time::sleep(backoff).await;
-                    backoff = (backoff * 2).min(Duration::from_secs(30));
+pub struct ControlClientService {
+    pub ctld_addr: SocketAddr,
+}
+
+impl BackgroundService for ControlClientService {
+    fn name(&self) -> &'static str {
+        "control-client"
+    }
+
+    fn run(
+        self: Box<Self>,
+        state: Arc<ServerState>,
+        shutdown: CancellationToken,
+        _proxy_handle: tokio::runtime::Handle,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send>> {
+        Box::pin(async move {
+            watch_loop(self.ctld_addr, state, shutdown).await;
+            Ok(())
+        })
+    }
+}
+
+
+async fn watch_loop(ctld_addr: SocketAddr, state: Arc<ServerState>, shutdown: CancellationToken) {
+    let mut backoff = Duration::from_secs(1);
+    let mut last_version: u64 = 0;
+    loop {
+        tokio::select! {
+            _ = shutdown.cancelled() => return,
+            result = connect_and_watch(ctld_addr, &state, last_version) => {
+                match result {
+                    Ok(version) => {
+                        last_version = version;
+                        backoff = Duration::from_secs(1);
+                    }
+                    Err(e) => {
+                        error!(error = %e, addr = %ctld_addr, "ctld watch connection failed");
+                        tokio::select! {
+                            _ = shutdown.cancelled() => return,
+                            _ = tokio::time::sleep(backoff) => {}
+                        }
+                        backoff = (backoff * 2).min(Duration::from_secs(30));
+                    }
                 }
             }
         }
-    });
+    }
 }
 
 async fn connect_and_watch(

--- a/server/handlers/http.rs
+++ b/server/handlers/http.rs
@@ -2,20 +2,21 @@ use crate::{metrics, ServerState};
 use anyhow::Result;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::net::TcpStream;
+use tokio::net::{TcpListener, TcpStream};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 use tunnel_lib::extract_host_from_http;
 use tunnel_lib::proxy;
 use tunnel_lib::RouteTarget;
-pub async fn run_http_listener(
+
+pub async fn run_http_accept_loop(
+    listener: Arc<TcpListener>,
     state: Arc<ServerState>,
     port: u16,
     cancel: CancellationToken,
 ) -> Result<()> {
-    let addr = format!("0.0.0.0:{}", port);
-    let listener = tunnel_lib::build_reuseport_listener(addr.parse()?)?;
-    info!(addr = %addr, "http listener started");
+    let addr = listener.local_addr()?;
+    info!(addr = %addr, "http accept loop started");
     loop {
         let (stream, peer_addr) = tokio::select! {
             _ = cancel.cancelled() => {
@@ -35,7 +36,7 @@ pub async fn run_http_listener(
             }
         };
         let state = state.clone();
-        crate::spawn_task(async move {
+        tokio::task::spawn(async move {
             let _permit = permit;
             metrics::tcp_connection_opened();
             let result = handle_http_connection(state, stream, port).await;

--- a/server/handlers/metrics.rs
+++ b/server/handlers/metrics.rs
@@ -1,42 +1,67 @@
 use crate::metrics;
 use anyhow::Result;
+use http_body_util::Full;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper_util::rt::TokioIo;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
+use tokio_util::sync::CancellationToken;
 use tracing::info;
 
-pub async fn run_metrics_server(port: u16, ready: Arc<AtomicBool>) -> Result<()> {
-    use metrics_exporter_prometheus::PrometheusBuilder;
-    let handle = PrometheusBuilder::new().install_recorder().expect("failed to install prometheus recorder");
-    crate::metrics::set_handle(handle);
-    let addr = format!("0.0.0.0:{}", port);
-    let listener = TcpListener::bind(&addr).await?;
-    info!(addr = %addr, "metrics server started");
+pub async fn run_metrics_server(
+    port: u16,
+    ready: Arc<AtomicBool>,
+    shutdown: CancellationToken,
+) -> Result<()> {
+    let listener = TcpListener::bind(format!("0.0.0.0:{port}")).await?;
+    info!(port, "metrics server started");
     loop {
-        let (mut stream, _) = listener.accept().await?;
-        let ready = ready.clone();
-        crate::spawn_task(async move {
-            let mut buf = [0u8; 512];
-            let n = stream.read(&mut buf).await.unwrap_or(0);
-            let req = std::str::from_utf8(&buf[..n]).unwrap_or("");
-            let is_health = req.starts_with("GET /healthz");
-            let (status, body) = if is_health {
-                if ready.load(Ordering::Acquire) {
-                    ("200 OK", "ok\n".to_string())
-                } else {
-                    ("503 Service Unavailable", "not ready\n".to_string())
-                }
-            } else {
-                ("200 OK", metrics::encode())
-            };
-            let response = format!(
-                "HTTP/1.1 {}\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\n\r\n{}",
-                status,
-                body.len(),
-                body
-            );
-            let _ = stream.write_all(response.as_bytes()).await;
-        });
+        tokio::select! {
+            _ = shutdown.cancelled() => break,
+            result = listener.accept() => {
+                let (stream, _) = result?;
+                let ready = ready.clone();
+                tokio::task::spawn(async move {
+                    let io = TokioIo::new(stream);
+                    let _ = http1::Builder::new()
+                        .keep_alive(true)
+                        .serve_connection(
+                            io,
+                            service_fn(move |req| {
+                                let ready = ready.clone();
+                                async move { handle_request(req, &ready).await }
+                            }),
+                        )
+                        .await;
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn handle_request(
+    req: hyper::Request<hyper::body::Incoming>,
+    ready: &Arc<AtomicBool>,
+) -> Result<hyper::Response<Full<bytes::Bytes>>, std::convert::Infallible> {
+    if req.uri().path() == "/healthz" {
+        let (status, body) = if ready.load(Ordering::Acquire) {
+            (200u16, "ok\n")
+        } else {
+            (503u16, "not ready\n")
+        };
+        Ok(hyper::Response::builder()
+            .status(status)
+            .body(Full::new(bytes::Bytes::from(body)))
+            .unwrap())
+    } else {
+        let body = metrics::encode();
+        Ok(hyper::Response::builder()
+            .status(200)
+            .header("content-type", "text/plain; charset=utf-8")
+            .body(Full::new(bytes::Bytes::from(body)))
+            .unwrap())
     }
 }

--- a/server/handlers/quic.rs
+++ b/server/handlers/quic.rs
@@ -34,7 +34,7 @@ pub async fn run_quic_server(state: Arc<ServerState>, ready: Arc<AtomicBool>) ->
                 continue;
             }
         };
-        crate::spawn_task(async move {
+        tokio::task::spawn(async move {
             let _permit = permit;
             metrics::quic_connection_opened();
             if let Err(e) = handle_quic_connection(state, incoming).await {
@@ -147,7 +147,7 @@ async fn handle_quic_connection(state: Arc<ServerState>, incoming: quinn::Incomi
                     Ok((send, recv)) => {
                         debug!("accepted reverse stream from client");
                         let state = state.clone();
-                        crate::spawn_task(async move {
+                        tokio::task::spawn(async move {
                             let egress_map = state.routing.load().egress_map.clone();
                             if let Err(e) = tunnel_handler::handle_tunnel_stream(send, recv, EgressProxy(egress_map)).await {
                                 debug!(error = %e, "egress stream error");

--- a/server/handlers/tcp.rs
+++ b/server/handlers/tcp.rs
@@ -2,22 +2,21 @@ use crate::{metrics, ServerState};
 use anyhow::Result;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::net::TcpStream;
+use tokio::net::{TcpListener, TcpStream};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 use tunnel_lib::proxy;
-pub async fn run_tcp_listener(
+
+pub async fn run_tcp_accept_loop(
+    listener: Arc<TcpListener>,
     state: Arc<ServerState>,
-    port: u16,
+    _port: u16,
     proxy_name: String,
     group_id: String,
     cancel: CancellationToken,
 ) -> Result<()> {
-    let addr = format!("0.0.0.0:{}", port);
-    let listener = tunnel_lib::build_reuseport_listener(addr.parse()?)?;
-    info!(
-        addr = % addr, proxy = % proxy_name, group = % group_id, "TCP listener started"
-    );
+    let addr = listener.local_addr()?;
+    info!(addr = %addr, proxy = %proxy_name, group = %group_id, "TCP accept loop started");
     loop {
         let (stream, peer_addr) = tokio::select! {
             _ = cancel.cancelled() => {
@@ -39,7 +38,7 @@ pub async fn run_tcp_listener(
         let state = state.clone();
         let proxy_name = proxy_name.clone();
         let group_id = group_id.clone();
-        crate::spawn_task(async move {
+        tokio::task::spawn(async move {
             let _permit = permit;
             metrics::tcp_connection_opened();
             let result = handle_tcp_connection(state, stream, proxy_name, group_id).await;

--- a/server/hot_reload.rs
+++ b/server/hot_reload.rs
@@ -1,19 +1,44 @@
 use crate::config::ServerConfigFile;
+use crate::service::BackgroundService;
 use crate::{build_routing_snapshot, ServerState};
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 use tunnel_lib::HttpClientParams;
-pub fn spawn_config_watcher(config_path: String, state: Arc<ServerState>) {
-    crate::spawn_task(async move {
-        if let Err(e) = watch_loop(config_path, state).await {
-            error!(error = %e, "hot-reload watcher exited unexpectedly");
-        }
-    });
+
+pub struct HotReloadService {
+    pub config_path: String,
 }
-async fn watch_loop(config_path: String, state: Arc<ServerState>) -> anyhow::Result<()> {
+
+impl BackgroundService for HotReloadService {
+    fn name(&self) -> &'static str {
+        "hot-reload"
+    }
+
+    fn run(
+        self: Box<Self>,
+        state: Arc<ServerState>,
+        shutdown: CancellationToken,
+        _proxy_handle: tokio::runtime::Handle,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send>> {
+        Box::pin(async move {
+            if let Err(e) = watch_loop(self.config_path, state, shutdown).await {
+                error!(error = %e, "hot-reload watcher exited unexpectedly");
+            }
+            Ok(())
+        })
+    }
+}
+
+
+async fn watch_loop(
+    config_path: String,
+    state: Arc<ServerState>,
+    shutdown: CancellationToken,
+) -> anyhow::Result<()> {
     let (tx, mut rx) = mpsc::channel::<()>(1);
     let mut watcher = RecommendedWatcher::new(
         move |res: notify::Result<notify::Event>| {
@@ -43,23 +68,29 @@ async fn watch_loop(config_path: String, state: Arc<ServerState>) -> anyhow::Res
     watcher.watch(watch_dir, RecursiveMode::NonRecursive)?;
     info!(path = %config_path, "hot-reload watcher started");
     loop {
-        if rx.recv().await.is_none() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(50)).await;
-        while rx.try_recv().is_ok() {}
-        info!(path = %config_path, "config change detected, reloading");
-        match reload_routing(&config_path, &state).await {
-            Ok(()) => info!(path = %config_path, "hot reload successful"),
-            Err(e) => warn!(
-                path = %config_path,
-                error = %e,
-                "hot reload failed, keeping previous config"
-            ),
+        tokio::select! {
+            _ = shutdown.cancelled() => break,
+            result = rx.recv() => {
+                if result.is_none() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                while rx.try_recv().is_ok() {}
+                info!(path = %config_path, "config change detected, reloading");
+                match reload_routing(&config_path, &state).await {
+                    Ok(()) => info!(path = %config_path, "hot reload successful"),
+                    Err(e) => warn!(
+                        path = %config_path,
+                        error = %e,
+                        "hot reload failed, keeping previous config"
+                    ),
+                }
+            }
         }
     }
     Ok(())
 }
+
 async fn reload_routing(config_path: &str, state: &Arc<ServerState>) -> anyhow::Result<()> {
     let http_params = HttpClientParams::from(&state.config.server.http_pool);
     let (tm, egress) = match ServerConfigFile::load(config_path) {

--- a/server/listener_mgr.rs
+++ b/server/listener_mgr.rs
@@ -131,7 +131,14 @@ pub fn sync_listeners(state: &Arc<ServerState>, desired: &[IngressListener]) {
         spawns
     }; // lock released here
 
-    // 3. Spawn tasks outside the lock.
+    // 3. Spawn N accept loops per listener outside the lock.
+    let accept_workers = state
+        .config
+        .server
+        .accept_workers
+        .unwrap_or(4)
+        .max(1);
+
     for desc in to_spawn {
         let SpawnDesc {
             port,
@@ -141,42 +148,69 @@ pub fn sync_listeners(state: &Arc<ServerState>, desired: &[IngressListener]) {
             tcp_group,
             tcp_proxy,
         } = desc;
+
+        let addr = format!("0.0.0.0:{}", port);
+        let listener = match tunnel_lib::build_reuseport_listener(addr.parse().unwrap()) {
+            Ok(l) => Arc::new(l),
+            Err(e) => {
+                error!(port = %port, error = %e, "failed to bind listener");
+                continue;
+            }
+        };
+
         match mode {
             IngressMode::Http(_) => {
-                let s = state.clone();
-                crate::spawn_task(async move {
-                    if let Err(e) =
-                        crate::handlers::http::run_http_listener(s.clone(), port, cancel).await
-                    {
-                        error!(port = %port, error = %e, "HTTP listener failed");
-                    }
-                    let mut map = s.listeners.map.lock();
-                    if map.get(&port).map(|e| e.id == listener_id).unwrap_or(false) {
-                        map.remove(&port);
-                    }
-                });
+                for i in 0..accept_workers {
+                    let s = state.clone();
+                    let listener = listener.clone();
+                    let cancel = cancel.clone();
+                    let is_last = i == accept_workers - 1;
+                    tokio::task::spawn(async move {
+                        if let Err(e) =
+                            crate::handlers::http::run_http_accept_loop(listener, s.clone(), port, cancel).await
+                        {
+                            error!(port = %port, error = %e, "HTTP accept loop failed");
+                        }
+                        if is_last {
+                            let mut map = s.listeners.map.lock();
+                            if map.get(&port).map(|e| e.id == listener_id).unwrap_or(false) {
+                                map.remove(&port);
+                            }
+                        }
+                    });
+                }
             }
             IngressMode::Tcp(_) => {
-                let s = state.clone();
                 let group_id = tcp_group.unwrap_or_default();
                 let proxy_name = tcp_proxy.unwrap_or_default();
-                crate::spawn_task(async move {
-                    if let Err(e) = crate::handlers::tcp::run_tcp_listener(
-                        s.clone(),
-                        port,
-                        proxy_name,
-                        group_id,
-                        cancel,
-                    )
-                    .await
-                    {
-                        error!(port = %port, error = %e, "TCP listener failed");
-                    }
-                    let mut map = s.listeners.map.lock();
-                    if map.get(&port).map(|e| e.id == listener_id).unwrap_or(false) {
-                        map.remove(&port);
-                    }
-                });
+                for i in 0..accept_workers {
+                    let s = state.clone();
+                    let listener = listener.clone();
+                    let cancel = cancel.clone();
+                    let proxy_name = proxy_name.clone();
+                    let group_id = group_id.clone();
+                    let is_last = i == accept_workers - 1;
+                    tokio::task::spawn(async move {
+                        if let Err(e) = crate::handlers::tcp::run_tcp_accept_loop(
+                            listener,
+                            s.clone(),
+                            port,
+                            proxy_name,
+                            group_id,
+                            cancel,
+                        )
+                        .await
+                        {
+                            error!(port = %port, error = %e, "TCP accept loop failed");
+                        }
+                        if is_last {
+                            let mut map = s.listeners.map.lock();
+                            if map.get(&port).map(|e| e.id == listener_id).unwrap_or(false) {
+                                map.remove(&port);
+                            }
+                        }
+                    });
+                }
             }
         }
     }

--- a/server/main.rs
+++ b/server/main.rs
@@ -26,6 +26,7 @@ mod local_auth;
 mod metrics;
 mod null_stores;
 mod registry;
+mod service;
 mod tunnel_handler;
 use config::{
     ConfigSource, DbSource, FileSource, IngressMode, MergedSource, ServerConfigFile,
@@ -427,20 +428,29 @@ async fn background_main(
     config_path: String,
     ctld_addr: Option<&str>,
     shutdown: CancellationToken,
-    _proxy_handle: tokio::runtime::Handle,
+    proxy_handle: tokio::runtime::Handle,
 ) {
-    if let Some(addr_str) = ctld_addr {
+    use service::BackgroundService;
+
+    let svc: Box<dyn BackgroundService> = if let Some(addr_str) = ctld_addr {
         match addr_str.parse::<std::net::SocketAddr>() {
             Ok(addr) => {
                 info!(addr = %addr, "starting ctld watch client");
-                control_client::spawn_control_client(addr, state);
+                Box::new(control_client::ControlClientService { ctld_addr: addr })
             }
-            Err(e) => error!(error = %e, "invalid ctld_addr"),
+            Err(e) => {
+                error!(error = %e, "invalid ctld_addr");
+                return;
+            }
         }
     } else {
-        hot_reload::spawn_config_watcher(config_path, state);
+        Box::new(hot_reload::HotReloadService { config_path })
+    };
+
+    let name = svc.name();
+    if let Err(e) = svc.run(state, shutdown, proxy_handle).await {
+        error!(service = name, error = %e, "background service exited with error");
     }
-    shutdown.cancelled().await;
 }
 pub fn build_routing_snapshot(
     tm: &TunnelManagement,

--- a/server/main.rs
+++ b/server/main.rs
@@ -147,7 +147,7 @@ async fn async_main() -> Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Some(Commands::Token { action }) => handle_token_command(&cli.config, action).await,
-        Some(Commands::Run) | None => run_server(&cli.config, cli.ctld_addr.as_deref()),
+        Some(Commands::Run) | None => run_server(&cli.config, cli.ctld_addr.as_deref()).await,
     }
 }
 fn run_with_tokio(fut: impl Future<Output = Result<()>>) -> Result<()> {
@@ -253,7 +253,7 @@ async fn handle_token_command(config_path: &str, action: TokenAction) -> Result<
     }
     Ok(())
 }
-fn run_server(config_path: &str, ctld_addr: Option<&str>) -> Result<()> {
+async fn run_server(config_path: &str, ctld_addr: Option<&str>) -> Result<()> {
     let config = ServerConfigFile::load(config_path)?;
     if ctld_addr.is_none() {
         config::validate_server_config(&config)?;
@@ -273,8 +273,7 @@ fn run_server(config_path: &str, ctld_addr: Option<&str>) -> Result<()> {
         crate::metrics::set_handle(handle);
     }
 
-    let proxy_rt = tunnel_lib::build_proxy_runtime();
-    let proxy_handle = proxy_rt.handle().clone();
+    let proxy_handle = tokio::runtime::Handle::current();
     let shutdown = CancellationToken::new();
     let ready = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
@@ -302,8 +301,7 @@ fn run_server(config_path: &str, ctld_addr: Option<&str>) -> Result<()> {
     let shutdown_bg = shutdown.clone();
     let proxy_handle_bg = proxy_handle.clone();
     let background_thread = {
-        // build state synchronously in proxy_rt so async stores are initialised
-        let state = proxy_rt.block_on(build_server_state(&config, config_path, ctld_addr))?;
+        let state = build_server_state(&config, config_path, ctld_addr).await?;
         let state_bg = state.clone();
         let t = std::thread::spawn(move || {
             let rt = tunnel_lib::build_single_thread_runtime("bg-worker");
@@ -319,8 +317,7 @@ fn run_server(config_path: &str, ctld_addr: Option<&str>) -> Result<()> {
     };
     let (state, background_thread) = background_thread;
 
-    // ── proxy main (blocks main thread) ────────────────────────────────────────
-    let result = proxy_rt.block_on(proxy_main(state, shutdown, ready));
+    let result = proxy_main(state, shutdown, ready).await;
 
     background_thread.join().ok();
     if let Some(t) = metrics_thread {

--- a/server/main.rs
+++ b/server/main.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 #[cfg(feature = "dial9-telemetry")]
 use std::path::PathBuf;
 use tokio::sync::Semaphore;
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 mod config;
 mod control_client;
@@ -39,6 +40,7 @@ use tunnel_store::{AuthStore, RuleStore};
 static DIAL9_HANDLE: std::sync::OnceLock<dial9_tokio_telemetry::telemetry::TelemetryHandle> =
     std::sync::OnceLock::new();
 
+// proxy-rt–local spawn helper: used only inside proxy_main (multi-thread runtime).
 pub(crate) fn spawn_task<F>(future: F) -> tokio::task::JoinHandle<F::Output>
 where
     F: Future + Send + 'static,
@@ -144,15 +146,11 @@ async fn async_main() -> Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Some(Commands::Token { action }) => handle_token_command(&cli.config, action).await,
-        Some(Commands::Run) | None => run_server(&cli.config, cli.ctld_addr.as_deref()).await,
+        Some(Commands::Run) | None => run_server(&cli.config, cli.ctld_addr.as_deref()),
     }
 }
 fn run_with_tokio(fut: impl Future<Output = Result<()>>) -> Result<()> {
-    let mut builder = tokio::runtime::Builder::new_multi_thread();
-    tunnel_lib::apply_worker_threads(&mut builder);
-    builder.enable_all();
-    let runtime = builder.build()?;
-    runtime.block_on(fut)
+    tunnel_lib::build_proxy_runtime().block_on(fut)
 }
 #[cfg(feature = "dial9-telemetry")]
 fn run_with_dial9(trace_path: PathBuf, fut: impl Future<Output = Result<()>>) -> Result<()> {
@@ -254,10 +252,8 @@ async fn handle_token_command(config_path: &str, action: TokenAction) -> Result<
     }
     Ok(())
 }
-async fn run_server(config_path: &str, ctld_addr: Option<&str>) -> Result<()> {
+fn run_server(config_path: &str, ctld_addr: Option<&str>) -> Result<()> {
     let config = ServerConfigFile::load(config_path)?;
-    // In standalone mode the routing sections are used at runtime, so validate them.
-    // In ctld-managed mode the routing sections are ignored by the server, so skip.
     if ctld_addr.is_none() {
         config::validate_server_config(&config)?;
     }
@@ -266,6 +262,78 @@ async fn run_server(config_path: &str, ctld_addr: Option<&str>) -> Result<()> {
     info!("Starting DuoTunnel Server");
     info!(tunnel_port = %config.server.tunnel_port, "Configuration loaded");
     tunnel_lib::init_cert_cache(&config.server.pki);
+
+    // Install Prometheus recorder before any runtime starts so no metrics are lost.
+    {
+        use metrics_exporter_prometheus::PrometheusBuilder;
+        let handle = PrometheusBuilder::new()
+            .install_recorder()
+            .expect("failed to install prometheus recorder");
+        crate::metrics::set_handle(handle);
+    }
+
+    let proxy_rt = tunnel_lib::build_proxy_runtime();
+    let proxy_handle = proxy_rt.handle().clone();
+    let shutdown = CancellationToken::new();
+    let ready = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+    // ── metrics thread ──────────────────────────────────────────────────────────
+    let metrics_thread = if let Some(metrics_port) = config.server.metrics_port {
+        let ready2 = ready.clone();
+        let shutdown2 = shutdown.clone();
+        Some(std::thread::spawn(move || {
+            let rt = tunnel_lib::build_single_thread_runtime("metrics-worker");
+            rt.block_on(async move {
+                if let Err(e) =
+                    handlers::metrics::run_metrics_server(metrics_port, ready2, shutdown2).await
+                {
+                    error!(port = %metrics_port, error = %e, "Metrics server failed");
+                }
+            });
+        }))
+    } else {
+        None
+    };
+
+    // ── background thread ───────────────────────────────────────────────────────
+    let config_path_bg = config_path.to_string();
+    let ctld_addr_bg = ctld_addr.map(|s| s.to_string());
+    let shutdown_bg = shutdown.clone();
+    let proxy_handle_bg = proxy_handle.clone();
+    let background_thread = {
+        // build state synchronously in proxy_rt so async stores are initialised
+        let state = proxy_rt.block_on(build_server_state(&config, config_path, ctld_addr))?;
+        let state_bg = state.clone();
+        let t = std::thread::spawn(move || {
+            let rt = tunnel_lib::build_single_thread_runtime("bg-worker");
+            rt.block_on(background_main(
+                state_bg,
+                config_path_bg,
+                ctld_addr_bg.as_deref(),
+                shutdown_bg,
+                proxy_handle_bg,
+            ));
+        });
+        (state, t)
+    };
+    let (state, background_thread) = background_thread;
+
+    // ── proxy main (blocks main thread) ────────────────────────────────────────
+    let result = proxy_rt.block_on(proxy_main(state, shutdown, ready));
+
+    background_thread.join().ok();
+    if let Some(t) = metrics_thread {
+        t.join().ok();
+    }
+
+    result
+}
+
+async fn build_server_state(
+    config: &ServerConfigFile,
+    config_path: &str,
+    ctld_addr: Option<&str>,
+) -> Result<Arc<ServerState>> {
     #[allow(clippy::type_complexity)]
     let (auth_store, rule_store, config_source, local_token_cache): (
         Arc<dyn AuthStore>,
@@ -273,7 +341,6 @@ async fn run_server(config_path: &str, ctld_addr: Option<&str>) -> Result<()> {
         Arc<dyn ConfigSource>,
         Option<Arc<local_auth::LocalTokenCache>>,
     ) = if ctld_addr.is_some() {
-        // ctld-managed mode: no local SQLite; all config comes from ctld watch stream.
         info!("running in ctld-managed mode; no local SQLite stores");
         let token_cache = Arc::new(local_auth::LocalTokenCache::new());
         let auth: Arc<dyn AuthStore> = token_cache.clone();
@@ -288,15 +355,13 @@ async fn run_server(config_path: &str, ctld_addr: Option<&str>) -> Result<()> {
         info!(url = %config.server.database_url, "auth and rule stores initialized (shared pool)");
         match rule_store.is_routing_empty().await {
             Ok(true) => {
-                if let Err(e) = config::sync_file_to_db(&config, rule_store.as_ref()).await {
+                if let Err(e) = config::sync_file_to_db(config, rule_store.as_ref()).await {
                     tracing::warn!(error = %e, "failed to seed routing DB from YAML (non-fatal)");
                 } else {
                     info!("routing rules seeded into DB from config file (first boot)");
                 }
             }
-            Ok(false) => {
-                info!("routing DB already populated, skipping YAML seed");
-            }
+            Ok(false) => info!("routing DB already populated, skipping YAML seed"),
             Err(e) => {
                 tracing::warn!(error = %e, "could not check routing DB state, skipping YAML seed");
             }
@@ -304,12 +369,13 @@ async fn run_server(config_path: &str, ctld_addr: Option<&str>) -> Result<()> {
         let cs = build_config_source(config_path, rule_store.clone());
         (auth_store, rule_store, cs, None)
     };
+
     let http_params = HttpClientParams::from(&config.server.http_pool);
     let (tm, egress) = config_source.load().await?;
     let initial_snapshot = build_routing_snapshot(&tm, &egress, &http_params);
     let (revocation_tx, _) = tokio::sync::broadcast::channel::<String>(64);
     let proxy_buffer_params = tunnel_lib::ProxyBufferParams::from(&config.server.proxy_buffers);
-    let state = Arc::new(ServerState {
+    Ok(Arc::new(ServerState {
         tcp_params: tunnel_lib::TcpParams::from(&config.server.tcp),
         peek_buf_pool: PeekBufPool::new(proxy_buffer_params.peek_buf_size),
         proxy_buffer_params,
@@ -324,39 +390,57 @@ async fn run_server(config_path: &str, ctld_addr: Option<&str>) -> Result<()> {
         revocation_tx,
         local_token_cache,
         listeners: listener_mgr::ListenerManager::new(),
-    });
+    }))
+}
+
+async fn proxy_main(
+    state: Arc<ServerState>,
+    shutdown: CancellationToken,
+    ready: Arc<std::sync::atomic::AtomicBool>,
+) -> Result<()> {
     info!(
-        max_quic_connections = %config.server.max_connections,
-        max_tcp_connections = %config.server.max_tcp_connections,
+        max_quic_connections = %state.config.server.max_connections,
+        max_tcp_connections = %state.config.server.max_tcp_connections,
         "Connection limits configured"
     );
 
-    if let Some(addr_str) = ctld_addr {
-        let addr: std::net::SocketAddr = addr_str.parse()?;
-        info!(addr = %addr, "starting ctld watch client");
-        control_client::spawn_control_client(addr, state.clone());
-    } else {
-        hot_reload::spawn_config_watcher(config_path.to_string(), state.clone());
+    // Sync initial listeners before QUIC starts.
+    {
+        let routing = state.routing.load();
+        let listeners: Vec<_> = routing.tunnel_management.server_ingress_routing.listeners.to_vec();
+        sync_listeners(&state, &listeners);
     }
 
-    let ready = Arc::new(std::sync::atomic::AtomicBool::new(false));
-    if let Some(metrics_port) = config.server.metrics_port {
-        let ready2 = ready.clone();
-        crate::spawn_task(async move {
-            if let Err(e) = handlers::metrics::run_metrics_server(metrics_port, ready2).await {
-                error!(port = %metrics_port, error = %e, "Metrics server failed");
-            }
-        });
-    }
     let quic_state = state.clone();
     let quic_handle =
         crate::spawn_task(async move { handlers::quic::run_quic_server(quic_state, ready).await });
-    {
-        let listeners: Vec<_> = tm.server_ingress_routing.listeners.to_vec();
-        sync_listeners(&state, &listeners);
+
+    tokio::select! {
+        r = quic_handle => { r??; }
+        _ = shutdown.cancelled() => {}
     }
-    quic_handle.await??;
     Ok(())
+}
+
+async fn background_main(
+    state: Arc<ServerState>,
+    config_path: String,
+    ctld_addr: Option<&str>,
+    shutdown: CancellationToken,
+    _proxy_handle: tokio::runtime::Handle,
+) {
+    if let Some(addr_str) = ctld_addr {
+        match addr_str.parse::<std::net::SocketAddr>() {
+            Ok(addr) => {
+                info!(addr = %addr, "starting ctld watch client");
+                control_client::spawn_control_client(addr, state);
+            }
+            Err(e) => error!(error = %e, "invalid ctld_addr"),
+        }
+    } else {
+        hot_reload::spawn_config_watcher(config_path, state);
+    }
+    shutdown.cancelled().await;
 }
 pub fn build_routing_snapshot(
     tm: &TunnelManagement,

--- a/server/service.rs
+++ b/server/service.rs
@@ -1,0 +1,15 @@
+use crate::ServerState;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
+
+pub trait BackgroundService: Send + 'static {
+    fn name(&self) -> &'static str;
+    fn run(
+        self: Box<Self>,
+        state: Arc<ServerState>,
+        shutdown: CancellationToken,
+        proxy_handle: tokio::runtime::Handle,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send>>;
+}

--- a/tunnel-lib/src/infra/runtime.rs
+++ b/tunnel-lib/src/infra/runtime.rs
@@ -7,3 +7,20 @@ pub fn apply_worker_threads(builder: &mut tokio::runtime::Builder) {
         }
     }
 }
+
+pub fn build_proxy_runtime() -> tokio::runtime::Runtime {
+    let mut b = tokio::runtime::Builder::new_multi_thread();
+    apply_worker_threads(&mut b);
+    b.enable_all()
+        .thread_name("proxy-worker")
+        .build()
+        .expect("proxy runtime")
+}
+
+pub fn build_single_thread_runtime(name: &str) -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .thread_name(name)
+        .build()
+        .expect("single thread runtime")
+}

--- a/tunnel-lib/src/lib.rs
+++ b/tunnel-lib/src/lib.rs
@@ -15,7 +15,7 @@ pub use egress::http::{
 pub use engine::bridge::relay_quic_to_tcp;
 pub use infra::peek_buf::PeekBufPool;
 pub use infra::pki::{get_or_create_server_config, init_cert_cache, PkiParams};
-pub use infra::runtime::apply_worker_threads;
+pub use infra::runtime::{apply_worker_threads, build_proxy_runtime, build_single_thread_runtime};
 pub use models::msg::{
     recv_message, recv_message_type, recv_routing_info, recv_typed_message, send_message,
     send_routing_info, ClientConfig, Login, LoginResp, MessageType, RoutingInfo, UpstreamConfig,

--- a/tunnel-store/src/server_config.rs
+++ b/tunnel-store/src/server_config.rs
@@ -63,6 +63,8 @@ pub struct ServerBasicConfig {
     pub open_stream_timeout_ms: u64,
     #[serde(default = "default_h2_single_authority")]
     pub h2_single_authority: bool,
+    #[serde(default)]
+    pub accept_workers: Option<usize>,
 }
 
 fn default_max_connections() -> usize {


### PR DESCRIPTION
- **refactor(runtime): extract runtime builders to tunnel-lib**
- **refactor(server): rewrite metrics server with hyper http1**
- **refactor(server): split into three runtimes**
- **refactor(server): add BackgroundService trait, convert hot_reload and control_client**
- **refactor(server): N-accept-loop for TCP/HTTP ingress listeners**
- **refactor(server): N-accept-loop for TCP/HTTP ingress listeners**
