### PR TITLE
refactor(msg): replace bincode with rkyv for wire serialization

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -25,7 +25,6 @@ serde_yaml = "0.9"
 anyhow = "1.0"
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-bincode = "1.3"
 clap = { version = "4.5", features = ["derive"] }
 dashmap = "6.1"
 bytes = "1.9"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -27,7 +27,6 @@ serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-bincode = "1.3"
 clap = { version = "4.5", features = ["derive"] }
 dashmap = "6.1"
 bytes = "1.9"

--- a/tunnel-lib/Cargo.toml
+++ b/tunnel-lib/Cargo.toml
@@ -12,7 +12,7 @@ tokio = { version = "1.49", features = ["full"] }
 tokio-util = { version = "0.7" }
 tracing = { version = "0.1" }
 serde = { version = "1.0", features = ["derive"] }
-bincode = "1.3"
+rkyv = { version = "0.8.15", default-features = false, features = ["std", "bytecheck", "alloc"] }
 anyhow = "1.0"
 bytes = "1.9"
 httparse = "1.9"

--- a/tunnel-lib/src/ctld_proto.rs
+++ b/tunnel-lib/src/ctld_proto.rs
@@ -10,23 +10,23 @@
 ///      ctld responds with a full Snapshot again (simplest correct behaviour; diffs are
 ///      a future optimisation).
 ///
-/// Wire framing: reuses the existing tunnel-lib send_message/recv_message bincode framing.
-///   [msg_type: u8 = 0x06 ConfigPush][len: u32 BE][bincode(WatchEvent)]
+/// Wire framing: reuses the existing tunnel-lib send_message/recv_message rkyv framing.
+///   [msg_type: u8 = 0x06 ConfigPush][len: u32 BE][rkyv(WatchEvent)]
 ///
 /// All types here are self-contained (no tunnel_store dependency) so this module
 /// can live in tunnel-lib and be used by both tunnel-service and server.
-use serde::{Deserialize, Serialize};
+use rkyv::{Archive, Deserialize, Serialize};
 
 // ── Ingress routing ───────────────────────────────────────────────────────────
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Archive, Serialize, Deserialize)]
 pub struct ProtoIngressVhostRule {
     pub match_host: String,
     pub group_id: String,
     pub proxy_name: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Archive, Serialize, Deserialize)]
 pub enum ProtoIngressListenerMode {
     Http {
         vhost: Vec<ProtoIngressVhostRule>,
@@ -37,7 +37,7 @@ pub enum ProtoIngressListenerMode {
     },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Archive, Serialize, Deserialize)]
 pub struct ProtoIngressListener {
     pub port: u16,
     pub mode: ProtoIngressListenerMode,
@@ -45,20 +45,20 @@ pub struct ProtoIngressListener {
 
 // ── Client groups & upstreams ─────────────────────────────────────────────────
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Archive, Serialize, Deserialize)]
 pub struct ProtoUpstreamServer {
     pub address: String,
     pub resolve: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Archive, Serialize, Deserialize)]
 pub struct ProtoClientUpstream {
     pub name: String,
     pub lb_policy: String,
     pub servers: Vec<ProtoUpstreamServer>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Archive, Serialize, Deserialize)]
 pub struct ProtoClientGroup {
     pub group_id: String,
     pub config_version: String,
@@ -67,13 +67,13 @@ pub struct ProtoClientGroup {
 
 // ── Egress ────────────────────────────────────────────────────────────────────
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Archive, Serialize, Deserialize)]
 pub struct ProtoEgressVhostRule {
     pub match_host: String,
     pub action_upstream: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Archive, Serialize, Deserialize)]
 pub struct ProtoEgressUpstreamDef {
     pub name: String,
     pub lb_policy: String,
@@ -83,7 +83,7 @@ pub struct ProtoEgressUpstreamDef {
 // ── Token cache ───────────────────────────────────────────────────────────────
 
 /// A single token entry in the in-memory cache sent to server.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Archive, Serialize, Deserialize)]
 pub struct TokenCacheEntry {
     /// Full 64-char hex SHA-256 of the raw token.
     pub hash_hex: String,
@@ -98,7 +98,7 @@ pub struct TokenCacheEntry {
 // ── Watch protocol ────────────────────────────────────────────────────────────
 
 /// Sent by the server to initiate (or resume) a watch session.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Archive, Serialize, Deserialize)]
 pub struct WatchRequest {
     /// The last resource_version the server has seen.
     /// 0 means "I have nothing; send me the full snapshot".
@@ -107,7 +107,7 @@ pub struct WatchRequest {
 
 /// The full config snapshot pushed by ctld as the list response,
 /// and also after each mutation (no delta in v1 for simplicity).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Archive, Serialize, Deserialize)]
 pub struct ConfigSnapshot {
     /// Monotonically increasing. Incremented on every write to ctld.
     pub resource_version: u64,
@@ -120,7 +120,7 @@ pub struct ConfigSnapshot {
 }
 
 /// Message envelope pushed from ctld → server over the watch stream.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Archive, Serialize, Deserialize)]
 pub enum WatchEvent {
     /// Full state snapshot (response to WatchRequest or post-reconnect).
     Snapshot(ConfigSnapshot),

--- a/tunnel-lib/src/models/msg.rs
+++ b/tunnel-lib/src/models/msg.rs
@@ -1,7 +1,17 @@
 use crate::proxy::core::Protocol;
 use anyhow::{anyhow, Result};
-use serde::{Deserialize, Serialize};
+use rkyv::{
+    api::high::{HighDeserializer, HighSerializer, HighValidator},
+    bytecheck::CheckBytes,
+    rancor,
+    ser::allocator::ArenaHandle,
+    util::AlignedVec,
+    Archive, Deserialize, Serialize,
+};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+const MAX_MESSAGE_BYTES: usize = 10 * 1024 * 1024;
+
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MessageType {
@@ -25,11 +35,11 @@ impl MessageType {
         }
     }
 }
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Archive, Serialize, Deserialize)]
 pub struct Login {
     pub token: String,
 }
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Archive, Serialize, Deserialize)]
 pub struct LoginResp {
     pub success: bool,
     pub error: Option<String>,
@@ -54,23 +64,23 @@ impl LoginResp {
         }
     }
 }
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Default, Archive, Serialize, Deserialize)]
 pub struct ClientConfig {
     pub config_version: String,
     pub upstreams: Vec<UpstreamConfig>,
 }
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Archive, Serialize, Deserialize)]
 pub struct UpstreamConfig {
     pub name: String,
     pub servers: Vec<UpstreamServer>,
     pub lb_policy: String,
 }
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Archive, Serialize, Deserialize)]
 pub struct UpstreamServer {
     pub address: String,
     pub resolve: bool,
 }
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Archive, Serialize, Deserialize)]
 pub struct RoutingInfo {
     pub proxy_name: String,
     pub src_addr: String,
@@ -78,13 +88,15 @@ pub struct RoutingInfo {
     pub protocol: Protocol,
     pub host: Option<String>,
 }
+
 pub async fn send_message<W, M>(writer: &mut W, msg_type: MessageType, msg: &M) -> Result<()>
 where
     W: AsyncWriteExt + Unpin,
-    M: Serialize,
+    M: for<'a> Serialize<HighSerializer<AlignedVec, ArenaHandle<'a>, rancor::Error>>,
 {
-    let payload = bincode::serialize(msg)?;
-    if payload.len() > 10 * 1024 * 1024 {
+    let payload = rkyv::to_bytes::<rancor::Error>(msg)
+        .map_err(|e| anyhow!("rkyv serialize failed: {e}"))?;
+    if payload.len() > MAX_MESSAGE_BYTES {
         return Err(anyhow!(
             "Message too large to send: {} bytes",
             payload.len()
@@ -107,20 +119,29 @@ where
 pub async fn recv_message<R, M>(reader: &mut R) -> Result<M>
 where
     R: AsyncReadExt + Unpin,
-    M: for<'de> Deserialize<'de>,
+    M: Archive,
+    M::Archived: for<'a> CheckBytes<HighValidator<'a, rancor::Error>>
+        + Deserialize<M, HighDeserializer<rancor::Error>>,
 {
     let len = reader.read_u32().await? as usize;
-    if len > 10 * 1024 * 1024 {
+    if len > MAX_MESSAGE_BYTES {
         return Err(anyhow!("Message too large: {} bytes", len));
     }
-    let mut buf = vec![0u8; len];
-    reader.read_exact(&mut buf).await?;
-    Ok(bincode::deserialize(&buf)?)
+    let mut buf = AlignedVec::<16>::with_capacity(len);
+    buf.resize(len, 0);
+    reader.read_exact(&mut buf[..]).await?;
+    let archived = rkyv::access::<M::Archived, rancor::Error>(&buf[..])
+        .map_err(|e| anyhow!("rkyv access failed: {e}"))?;
+    let value = rkyv::deserialize::<M, rancor::Error>(archived)
+        .map_err(|e| anyhow!("rkyv deserialize failed: {e}"))?;
+    Ok(value)
 }
 pub async fn recv_typed_message<R, M>(reader: &mut R, expected: MessageType) -> Result<M>
 where
     R: AsyncReadExt + Unpin,
-    M: for<'de> Deserialize<'de>,
+    M: Archive,
+    M::Archived: for<'a> CheckBytes<HighValidator<'a, rancor::Error>>
+        + Deserialize<M, HighDeserializer<rancor::Error>>,
 {
     let msg_type = recv_message_type(reader).await?;
     if msg_type != expected {
@@ -143,13 +164,27 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    fn encode<T>(value: &T) -> AlignedVec
+    where
+        T: for<'a> Serialize<HighSerializer<AlignedVec, ArenaHandle<'a>, rancor::Error>>,
+    {
+        rkyv::to_bytes::<rancor::Error>(value).unwrap()
+    }
+    fn decode<T>(bytes: &[u8]) -> T
+    where
+        T: Archive,
+        T::Archived: for<'a> CheckBytes<HighValidator<'a, rancor::Error>>
+            + Deserialize<T, HighDeserializer<rancor::Error>>,
+    {
+        rkyv::from_bytes::<T, rancor::Error>(bytes).unwrap()
+    }
     #[test]
     fn test_login_serialize() {
         let login = Login {
             token: "dt_test123".to_string(),
         };
-        let encoded = bincode::serialize(&login).unwrap();
-        let decoded: Login = bincode::deserialize(&encoded).unwrap();
+        let encoded = encode(&login);
+        let decoded: Login = decode(&encoded);
         assert_eq!(login.token, decoded.token);
     }
     #[test]
@@ -161,8 +196,8 @@ mod tests {
             protocol: Protocol::H1,
             host: Some("example.com".to_string()),
         };
-        let encoded = bincode::serialize(&info).unwrap();
-        let decoded: RoutingInfo = bincode::deserialize(&encoded).unwrap();
+        let encoded = encode(&info);
+        let decoded: RoutingInfo = decode(&encoded);
         assert_eq!(info.proxy_name, decoded.proxy_name);
         assert_eq!(info.host, decoded.host);
     }
@@ -200,8 +235,8 @@ mod tests {
             protocol: Protocol::Tcp,
             host: None,
         };
-        let encoded = bincode::serialize(&info).unwrap();
-        let decoded: RoutingInfo = bincode::deserialize(&encoded).unwrap();
+        let encoded = encode(&info);
+        let decoded: RoutingInfo = decode(&encoded);
         assert_eq!(decoded.host, None);
         assert_eq!(decoded.protocol, Protocol::Tcp);
     }

--- a/tunnel-lib/src/proxy/core.rs
+++ b/tunnel-lib/src/proxy/core.rs
@@ -4,7 +4,9 @@ use crate::models::msg::RoutingInfo;
 use anyhow::Result;
 use std::net::SocketAddr;
 use std::sync::OnceLock;
-#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize,
+)]
 pub enum Protocol {
     H1,
     H2,

--- a/tunnel-service/Cargo.toml
+++ b/tunnel-service/Cargo.toml
@@ -18,7 +18,6 @@ async-trait = "0.1"
 anyhow = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-bincode = "1.3"
 serde = { version = "1.0", features = ["derive"] }
 clap = { version = "4.5", features = ["derive"] }
 figment = { version = "0.10", features = ["yaml", "env"] }


### PR DESCRIPTION
## Summary

- **Why now**: bincode's upstream repo was archived on 2025-08-15 and no longer accepts fixes. Picking a healthier codec before more code piles on top.
- **What**: swap the internal control-plane framing (`send_message` / `recv_message` / `send_routing_info` / `recv_routing_info` in `tunnel-lib`) from bincode 1.x to rkyv 0.8.15.
- **External API is unchanged**: all 8 call sites in `server/`, `client/`, `tunnel-service/` compile without edits.

## Design notes

- rkyv **high-level API** (`rkyv::to_bytes`, `rkyv::access`, `rkyv::deserialize`) with `rancor::Error` and `bytecheck` validation enabled.
- Take the `deserialize()` path (not zero-copy) on receive so call sites keep receiving owned `M` — the control plane isn't hot enough to justify the zero-copy ergonomic cost (`&ArchivedM`, field-type rewrites, lifetime churn).
- `recv_message` now allocates an `AlignedVec<16>` so rkyv's alignment precondition holds. Frame layout (`[type:u8][len:u32 BE][payload]`) and the 10 MiB size ceiling are unchanged.
- `Protocol` enum (`tunnel-lib/src/proxy/core.rs`) moves from `serde` derive to rkyv derive since it's only serialized through this path.
- Drop the stale `bincode = \"1.3\"` declaration from `server/`, `client/`, `tunnel-service/` Cargo.toml — none of them had any `bincode::` usage.

## Known trade-offs

- **Wire size grows ~30%** vs. bincode (rkyv padding + metadata). The control path is low-volume (login, routing info, watch snapshot) so this is not hot.
- **Generic `where` clauses got longer** in `msg.rs` (HighSerializer / HighDeserializer / HighValidator bounds). Contained to one file.
- Wire format is **not backward compatible** with the old bincode bytes — server and client must be rolled together.

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo test --workspace` — all pass (including 13 msg-module framing tests covering login/routing_info/size-limit/wrong-type rejection/multi-message pipe)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — 0 warning
- [ ] End-to-end smoke: start ctld + server + client, verify login + watch snapshot + a real tunnel connection
- [ ] Verify no regression on existing CI helpers