### PR TITLE
chore: pin rust 1.95, land batch A upgrades, apply 1.95 idioms

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -14,7 +14,7 @@ dial9-telemetry = ["dep:dial9-tokio-telemetry"]
 
 [dependencies]
 tunnel-lib = { path = "../tunnel-lib" }
-tokio = { version = "1.49", features = ["full"] }
+tokio = { version = "1.52", features = ["full"] }
 tokio-util = { version = "0.7", features = ["io", "codec"] }
 quinn = { version = "0.11", default-features = false, features = ["log", "platform-verifier", "runtime-tokio", "rustls-aws-lc-rs", "bloom"] }
 rustls = { version = "0.23", features = ["aws_lc_rs"] }
@@ -25,11 +25,11 @@ serde_yaml = "0.9"
 anyhow = "1.0"
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 dashmap = "6.1"
 bytes = "1.9"
 httparse = "1.9"
-hyper = { version = "1.8", features = ["client", "server", "http1", "http2"] }
+hyper = { version = "1.9", features = ["client", "server", "http1", "http2"] }
 hyper-util = { version = "0.1", features = ["client", "client-legacy", "http1", "http2", "tokio"] }
 hyper-rustls = { version = "0.27", features = ["http2", "aws-lc-rs"] }
 rustls-native-certs = "0.8"
@@ -38,7 +38,7 @@ http-body-util = "0.1"
 futures-util = "0.3"
 async-trait = "0.1"
 http = "1.0"
-arc-swap = "1.7"
+arc-swap = "1.9"
 figment = { version = "0.10", features = ["yaml", "env"] }
 rand = "0.9"
 tikv-jemallocator = { version = "0.6", features = ["unprefixed_malloc_on_supported_platforms"] }

--- a/docs/rust-1.95-and-deps-upgrade-notes.md
+++ b/docs/rust-1.95-and-deps-upgrade-notes.md
@@ -1,6 +1,22 @@
 # Rust 1.95 And Dependency Upgrade Notes
 
-Last checked: 2026-04-17
+Last checked: 2026-04-18
+
+## Progress (2026-04-18)
+
+- Toolchain pinned to 1.95.0 via `rust-toolchain.toml`.
+- Batch A landed: `tokio 1.49 → 1.52`, `hyper 1.8 → 1.9`, `clap 4.5 → 4.6`,
+  `arc-swap` normalised to `1.9` across workspace. `rustls`/`hyper-rustls`/
+  `tracing-subscriber`/`rand` caret constraints already resolve to the
+  recommended patch versions via `Cargo.lock`.
+- Rust 1.95 idioms applied:
+  - `Vec::push_mut` in `tunnel-store/src/sqlite_rules.rs`
+    (egress upstream + client upstream build paths).
+  - `if let` guards in `server/hot_reload.rs` (notify event filter).
+- `bincode` path is obsolete — moved to `rkyv 0.8.15` in PR #25. The
+  "Batch C: bincode" row below is now historical.
+- Remaining: Batch B (tonic/prost, notify, metrics-exporter-prometheus,
+  tokio-tungstenite, webpki-roots, socket2).
 
 ## Scope
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.95.0"
+components = ["rustfmt", "clippy"]
+profile = "minimal"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -17,7 +17,7 @@ tunnel-lib = { path = "../tunnel-lib" }
 tunnel-store = { path = "../tunnel-store", features = ["server-config"] }
 subtle = "2"
 hex = "0.4"
-tokio = { version = "1.49", features = ["full", "io-util"] }
+tokio = { version = "1.52", features = ["full", "io-util"] }
 tokio-util = "0.7"
 quinn = { version = "0.11", default-features = false, features = ["log", "platform-verifier", "runtime-tokio", "rustls-aws-lc-rs", "bloom"] }
 rustls = { version = "0.23", features = ["aws_lc_rs"] }
@@ -27,12 +27,12 @@ serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 dashmap = "6.1"
 bytes = "1.9"
 httparse = "1.9"
 rcgen = "0.14"
-hyper = { version = "1.8", features = ["client", "server", "http1", "http2"] }
+hyper = { version = "1.9", features = ["client", "server", "http1", "http2"] }
 hyper-util = { version = "0.1", features = ["client", "client-legacy", "http1", "http2", "tokio"] }
 hyper-rustls = { version = "0.27", features = ["http2", "aws-lc-rs"] }
 http-body-util = "0.1"
@@ -40,7 +40,7 @@ async-trait = "0.1"
 tokio-rustls = "0.26"
 metrics = "0.24"
 metrics-exporter-prometheus = "0.16"
-arc-swap = "1.7"
+arc-swap = "1.9"
 notify = { version = "6.1", features = ["macos_kqueue"] }
 figment = { version = "0.10", features = ["yaml", "env"] }
 parking_lot = "0.12"

--- a/server/hot_reload.rs
+++ b/server/hot_reload.rs
@@ -42,14 +42,12 @@ async fn watch_loop(
     let (tx, mut rx) = mpsc::channel::<()>(1);
     let mut watcher = RecommendedWatcher::new(
         move |res: notify::Result<notify::Event>| {
-            if let Ok(event) = res {
-                use notify::EventKind::*;
-                match event.kind {
-                    Create(_) | Modify(_) | Remove(_) => {
-                        let _ = tx.try_send(());
-                    }
-                    _ => {}
+            use notify::EventKind::*;
+            match res {
+                Ok(event) if let Create(_) | Modify(_) | Remove(_) = event.kind => {
+                    let _ = tx.try_send(());
                 }
+                _ => {}
             }
         },
         notify::Config::default(),

--- a/tunnel-lib/Cargo.toml
+++ b/tunnel-lib/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 quinn = { version = "0.11", default-features = false, features = ["log", "platform-verifier", "runtime-tokio", "rustls-aws-lc-rs", "bloom"] }
 rustls = { version = "0.23", features = ["aws_lc_rs"] }
 rcgen = "0.14"
-tokio = { version = "1.49", features = ["full"] }
+tokio = { version = "1.52", features = ["full"] }
 tokio-util = { version = "0.7" }
 tracing = { version = "0.1" }
 serde = { version = "1.0", features = ["derive"] }
@@ -16,7 +16,7 @@ rkyv = { version = "0.8.15", default-features = false, features = ["std", "bytec
 anyhow = "1.0"
 bytes = "1.9"
 httparse = "1.9"
-hyper = { version = "1.8", features = ["client", "server", "http1", "http2"] }
+hyper = { version = "1.9", features = ["client", "server", "http1", "http2"] }
 hyper-util = { version = "0.1", features = ["client", "client-legacy", "http1", "http2", "tokio"] }
 hyper-rustls = { version = "0.27", features = ["http2", "aws-lc-rs"] }
 http-body-util = "0.1"
@@ -24,7 +24,7 @@ futures-util = "0.3"
 async-trait = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 http = "1.0"
-arc-swap = "1"
+arc-swap = "1.9"
 crossbeam-utils = "0.8"
 dashmap = "6.1"
 parking_lot = "0.12"

--- a/tunnel-service/Cargo.toml
+++ b/tunnel-service/Cargo.toml
@@ -12,16 +12,16 @@ path = "src/main.rs"
 tunnel-store = { path = "../tunnel-store", features = ["sqlite", "server-config"] }
 tunnel-lib = { path = "../tunnel-lib" }
 sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }
-tokio = { version = "1.49", features = ["full"] }
+tokio = { version = "1.52", features = ["full"] }
 tokio-util = "0.7"
 async-trait = "0.1"
 anyhow = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 serde = { version = "1.0", features = ["derive"] }
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.6", features = ["derive"] }
 figment = { version = "0.10", features = ["yaml", "env"] }
-arc-swap = "1.7"
+arc-swap = "1.9"
 subtle = "2"
 hex = "0.4"
 sha2 = "0.10"

--- a/tunnel-store/src/sqlite_rules.rs
+++ b/tunnel-store/src/sqlite_rules.rs
@@ -184,27 +184,26 @@ impl RuleStore for SqliteRuleStore {
                         let address: Option<String> = row.try_get("address").ok();
                         if let Some(addr) = address {
                             let resolve: i64 = row.get("resolve");
-                            if let Some(upstream) = last_group.upstreams.iter_mut().find(|u| {
-                                let upstream_name: String = row.get("upstream_name");
-                                u.name == upstream_name
-                            }) {
-                                upstream.servers.push(UpstreamServer {
-                                    address: addr,
-                                    resolve: resolve != 0,
-                                });
-                            } else {
-                                let upstream_name: String = row.get("upstream_name");
-                                let lb_policy: String = row.get("lb_policy");
-                                let resolve: i64 = row.get("resolve");
-                                last_group.upstreams.push(ClientUpstream {
-                                    name: upstream_name,
-                                    lb_policy,
-                                    servers: vec![UpstreamServer {
-                                        address: addr,
-                                        resolve: resolve != 0,
-                                    }],
-                                });
-                            }
+                            let upstream_name: String = row.get("upstream_name");
+                            let upstream = match last_group
+                                .upstreams
+                                .iter_mut()
+                                .position(|u| u.name == upstream_name)
+                            {
+                                Some(idx) => &mut last_group.upstreams[idx],
+                                None => {
+                                    let lb_policy: String = row.get("lb_policy");
+                                    last_group.upstreams.push_mut(ClientUpstream {
+                                        name: upstream_name,
+                                        lb_policy,
+                                        servers: Vec::new(),
+                                    })
+                                }
+                            };
+                            upstream.servers.push(UpstreamServer {
+                                address: addr,
+                                resolve: resolve != 0,
+                            });
                             let _ = uid;
                         }
                     }
@@ -261,19 +260,18 @@ impl RuleStore for SqliteRuleStore {
                 }
             }
             let lb_policy: String = row.get("lb_policy");
-            let mut servers = Vec::new();
+            let def = egress_upstreams.push_mut(EgressUpstreamDef {
+                name,
+                lb_policy,
+                servers: Vec::new(),
+            });
             if let Some(addr) = address {
                 let resolve: i64 = row.get("resolve");
-                servers.push(UpstreamServer {
+                def.servers.push(UpstreamServer {
                     address: addr,
                     resolve: resolve != 0,
                 });
             }
-            egress_upstreams.push(EgressUpstreamDef {
-                name,
-                lb_policy,
-                servers,
-            });
         }
         let vhost_rows =
             sqlx::query("SELECT match_host, action_upstream FROM egress_vhost_rules ORDER BY id")


### PR DESCRIPTION
## Summary

Implements the **"Suggested Upgrade Order" steps 1-3** from `docs/rust-1.95-and-deps-upgrade-notes.md`:

1. Pin the workspace toolchain baseline to Rust 1.95.
2. Land the Rust 1.95 code cleanups (`Vec::push_mut`, `if let` guards).
3. Upgrade the low-risk async/networking stack (Batch A).

## Changes

### Toolchain
- `rust-toolchain.toml` pins `1.95.0` with `rustfmt` + `clippy` so every environment (local + CI) matches.

### Batch A dependency upgrades
- `tokio` 1.49 → 1.52 (runtime fixes, `spawn_blocking` scalability improvements)
- `hyper` 1.8 → 1.9 (HTTP/1 parsing fixes, HTTP/2 builder knobs)
- `clap` 4.5 → 4.6 (CLI polish)
- `arc-swap` normalised to `"1.9"` across workspace (previously mixed `"1"` / `"1.7"`)
- `rustls` / `hyper-rustls` / `tracing-subscriber` / `rand` caret bounds unchanged — `Cargo.lock` naturally resolves to the note-recommended patch levels after `cargo update`

### Rust 1.95 idioms
- `tunnel-store/src/sqlite_rules.rs`: use `Vec::push_mut` to push the parent struct first and keep filling the newly-inserted element in place. Two call sites rewritten: egress upstream build path and client-group upstream build path.
- `server/hot_reload.rs`: collapse nested `if let Ok(event) = res { match event.kind { ... } }` into a single `match res { Ok(event) if let Create(_) | Modify(_) | Remove(_) = event.kind => ... }` using the new if-let guard.

### Docs
- `docs/rust-1.95-and-deps-upgrade-notes.md` gains a "Progress (2026-04-18)" section reflecting what has landed and what remains (Batch B).

## Not in this PR (deferred to separate PRs per the notes)

- Batch B: `tonic` / `prost`, `notify`, `metrics-exporter-prometheus`, `tokio-tungstenite`, `webpki-roots`, `socket2` — each needs its own PR with focused test coverage.

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo test --workspace` — all pass (76 tests across tunnel-lib)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — 0 warning
- [x] `rustc --version` confirmed 1.95.0 matches the toolchain pin
- [ ] Spot-check in production/staging that hot-reload still fires on config change (covered by existing integration flow but the `notify` event-filter path was refactored)