### PR TITLE
chore(deps): land Batch B upgrades (socket2, tokio-tungstenite, metrics-exporter-prometheus, notify, webpki-roots, tonic)

### DIFF
--- a/ci-helpers/Cargo.toml
+++ b/ci-helpers/Cargo.toml
@@ -26,7 +26,7 @@ tonic = { version = "0.12", features = ["tls", "tls-roots", "tls-native-roots"] 
 tonic-health = "0.12"
 prost = "0.13"
 tokio = { version = "1", features = ["full"] }
-tokio-tungstenite = "0.24"
+tokio-tungstenite = "0.29"
 futures-util = "0.3"
 hyper = { version = "1", features = ["http1", "http2", "client"] }
 hyper-util = { version = "0.1", features = ["tokio", "client", "client-legacy", "http1", "http2"] }

--- a/ci-helpers/Cargo.toml
+++ b/ci-helpers/Cargo.toml
@@ -21,10 +21,14 @@ path = "src/http_echo_server.rs"
 name = "ci-test-client"
 path = "src/ci_test_client.rs"
 
+[build-dependencies]
+tonic-prost-build = "0.14"
+
 [dependencies]
-tonic = { version = "0.12", features = ["tls", "tls-roots", "tls-native-roots"] }
-tonic-health = "0.12"
-prost = "0.13"
+tonic = { version = "0.14", features = ["tls-aws-lc", "tls-native-roots", "tls-webpki-roots"] }
+tonic-health = "0.14"
+tonic-prost = "0.14"
+prost = "0.14"
 tokio = { version = "1", features = ["full"] }
 tokio-tungstenite = "0.29"
 futures-util = "0.3"

--- a/ci-helpers/build.rs
+++ b/ci-helpers/build.rs
@@ -1,0 +1,7 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_prost_build::configure()
+        .build_client(true)
+        .build_server(true)
+        .compile_protos(&["proto/grpc_echo.proto"], &["proto"])?;
+    Ok(())
+}

--- a/ci-helpers/src/ci_test_client.rs
+++ b/ci-helpers/src/ci_test_client.rs
@@ -417,7 +417,7 @@ async fn run_ws(url: &str, args: &[String]) -> Result<String, String> {
     .map_err(|_| format!("WebSocket connect timeout to {url}"))?
     .map_err(|e| format!("WebSocket connect error: {e}"))?;
 
-    ws.send(Message::Text(message.clone()))
+    ws.send(Message::Text(message.clone().into()))
         .await
         .map_err(|e| format!("ws send error: {e}"))?;
 

--- a/ci-helpers/src/ci_test_client.rs
+++ b/ci-helpers/src/ci_test_client.rs
@@ -511,34 +511,14 @@ async fn run_grpc(addr: &str, args: &[String]) -> Result<String, String> {
 // Sends a ping message and validates the response body echoes it back.
 // Supports TLS (--tls).
 //
-// EchoRequest  { ping: string (tag 1) }
-// EchoResponse { headers: map<string,string> (tag 1), body: string (tag 2), remote_addr: string (tag 3) }
-//
 // Validates that the response body field contains the sent ping text.
 
-#[derive(Clone, prost::Message)]
-struct EchoRequest {
-    #[prost(string, tag = "1")]
-    pub ping: String,
+mod grpc_echo {
+    tonic::include_proto!("grpc_echo.v1");
 }
 
-#[derive(Clone, prost::Message)]
-struct StreamEchoRequest {
-    #[prost(string, tag = "1")]
-    pub ping: String,
-    #[prost(int32, tag = "2")]
-    pub count: i32,
-}
-
-#[derive(Clone, prost::Message)]
-struct EchoResponse {
-    #[prost(map = "string, string", tag = "1")]
-    pub headers: std::collections::HashMap<String, String>,
-    #[prost(string, tag = "2")]
-    pub body: String,
-    #[prost(string, tag = "3")]
-    pub remote_addr: String,
-}
+use grpc_echo::echo_service_client::EchoServiceClient;
+use grpc_echo::{EchoRequest, StreamEchoRequest};
 
 async fn run_grpc_echo(addr: &str, args: &[String]) -> Result<String, String> {
     let mut use_tls = false;
@@ -559,20 +539,13 @@ async fn run_grpc_echo(addr: &str, args: &[String]) -> Result<String, String> {
     }
 
     let channel = connect_grpc_channel(addr, use_tls).await?;
-
-    let mut grpc = tonic::client::Grpc::new(channel);
-    grpc.ready()
-        .await
-        .map_err(|e| format!("gRPC echo not ready: {e}"))?;
+    let mut client = EchoServiceClient::new(channel);
 
     let request = tonic::Request::new(EchoRequest {
         ping: ping_text.clone(),
     });
-    let codec = tonic::codec::ProstCodec::<EchoRequest, EchoResponse>::new();
-    let path =
-        tonic::codegen::http::uri::PathAndQuery::from_static("/grpc_echo.v1.EchoService/Echo");
 
-    let resp = tokio::time::timeout(Duration::from_secs(15), grpc.unary(request, path, codec))
+    let resp = tokio::time::timeout(Duration::from_secs(15), client.echo(request))
         .await
         .map_err(|_| "gRPC Echo timeout".to_string())?
         .map_err(|e| {
@@ -585,7 +558,6 @@ async fn run_grpc_echo(addr: &str, args: &[String]) -> Result<String, String> {
 
     let echo_resp = resp.into_inner();
 
-    // Validate: the echoed body must contain the ping text we sent.
     if !echo_resp.body.contains(&ping_text) {
         return Err(format!(
             "EchoService/Echo body mismatch: sent {:?}, got body={:?}",
@@ -631,24 +603,16 @@ async fn run_grpc_server_stream(addr: &str, args: &[String]) -> Result<String, S
     }
 
     let channel = connect_grpc_channel(addr, use_tls).await?;
-
-    let mut grpc = tonic::client::Grpc::new(channel);
-    grpc.ready()
-        .await
-        .map_err(|e| format!("gRPC not ready: {e}"))?;
+    let mut client = EchoServiceClient::new(channel);
 
     let request = tonic::Request::new(StreamEchoRequest {
         ping: ping_text.clone(),
         count,
     });
-    let codec = tonic::codec::ProstCodec::<StreamEchoRequest, EchoResponse>::new();
-    let path = tonic::codegen::http::uri::PathAndQuery::from_static(
-        "/grpc_echo.v1.EchoService/ServerStreamEcho",
-    );
 
     let resp = tokio::time::timeout(
         Duration::from_secs(15),
-        grpc.server_streaming(request, path, codec),
+        client.server_stream_echo(request),
     )
     .await
     .map_err(|_| "gRPC ServerStreamEcho timeout".to_string())?
@@ -719,13 +683,8 @@ async fn run_grpc_bidi_stream(addr: &str, args: &[String]) -> Result<String, Str
     }
 
     let channel = connect_grpc_channel(addr, use_tls).await?;
+    let mut client = EchoServiceClient::new(channel);
 
-    let mut grpc = tonic::client::Grpc::new(channel);
-    grpc.ready()
-        .await
-        .map_err(|e| format!("gRPC not ready: {e}"))?;
-
-    // Build the outbound stream
     let pings: Vec<EchoRequest> = (0..count)
         .map(|i| EchoRequest {
             ping: format!("{}:{}", ping_text, i),
@@ -734,14 +693,10 @@ async fn run_grpc_bidi_stream(addr: &str, args: &[String]) -> Result<String, Str
     let outbound = futures_util::stream::iter(pings);
 
     let request = tonic::Request::new(outbound);
-    let codec = tonic::codec::ProstCodec::<EchoRequest, EchoResponse>::new();
-    let path = tonic::codegen::http::uri::PathAndQuery::from_static(
-        "/grpc_echo.v1.EchoService/BidiStreamEcho",
-    );
 
     let resp = tokio::time::timeout(
         Duration::from_secs(15),
-        grpc.streaming(request, path, codec),
+        client.bidi_stream_echo(request),
     )
     .await
     .map_err(|_| "gRPC BidiStreamEcho timeout".to_string())?

--- a/ci-helpers/src/grpc_echo_server.rs
+++ b/ci-helpers/src/grpc_echo_server.rs
@@ -5,29 +5,12 @@ use tokio_stream::{wrappers::ReceiverStream, StreamExt};
 use tonic::{transport::Server, Request, Response, Status, Streaming};
 use tonic_health::{server::health_reporter, ServingStatus};
 
-#[derive(Clone, prost::Message)]
-struct EchoRequest {
-    #[prost(string, tag = "1")]
-    pub ping: String,
+pub mod grpc_echo {
+    tonic::include_proto!("grpc_echo.v1");
 }
 
-#[derive(Clone, prost::Message)]
-struct StreamEchoRequest {
-    #[prost(string, tag = "1")]
-    pub ping: String,
-    #[prost(int32, tag = "2")]
-    pub count: i32,
-}
-
-#[derive(Clone, prost::Message)]
-struct EchoResponse {
-    #[prost(map = "string, string", tag = "1")]
-    pub headers: HashMap<String, String>,
-    #[prost(string, tag = "2")]
-    pub body: String,
-    #[prost(string, tag = "3")]
-    pub remote_addr: String,
-}
+use grpc_echo::echo_service_server::{EchoService as EchoServiceTrait, EchoServiceServer};
+use grpc_echo::{EchoRequest, EchoResponse, StreamEchoRequest};
 
 #[derive(Debug, Default)]
 struct EchoService;
@@ -45,7 +28,7 @@ fn extract_headers(metadata: &tonic::metadata::MetadataMap) -> HashMap<String, S
 }
 
 #[tonic::async_trait]
-impl echo_service_trait::EchoServiceServer for EchoService {
+impl EchoServiceTrait for EchoService {
     async fn echo(&self, request: Request<EchoRequest>) -> Result<Response<EchoResponse>, Status> {
         let remote = request
             .remote_addr()
@@ -125,172 +108,6 @@ impl echo_service_trait::EchoServiceServer for EchoService {
     }
 }
 
-mod echo_service_trait {
-    use super::{EchoRequest, EchoResponse, StreamEchoRequest};
-    use std::pin::Pin;
-    use tonic::{Request, Response, Status, Streaming};
-
-    #[tonic::async_trait]
-    pub trait EchoServiceServer: Send + Sync + 'static {
-        async fn echo(
-            &self,
-            request: Request<EchoRequest>,
-        ) -> Result<Response<EchoResponse>, Status>;
-
-        type ServerStreamEchoStream: futures_util::Stream<Item = Result<EchoResponse, Status>>
-            + Send
-            + 'static;
-
-        async fn server_stream_echo(
-            &self,
-            request: Request<StreamEchoRequest>,
-        ) -> Result<Response<Self::ServerStreamEchoStream>, Status>;
-
-        type BidiStreamEchoStream: futures_util::Stream<Item = Result<EchoResponse, Status>>
-            + Send
-            + 'static;
-
-        async fn bidi_stream_echo(
-            &self,
-            request: Request<Streaming<EchoRequest>>,
-        ) -> Result<Response<Self::BidiStreamEchoStream>, Status>;
-    }
-
-    pub struct EchoServiceServerImpl<T: EchoServiceServer> {
-        inner: std::sync::Arc<T>,
-    }
-
-    impl<T: EchoServiceServer> EchoServiceServerImpl<T> {
-        pub fn new(inner: T) -> Self {
-            Self {
-                inner: std::sync::Arc::new(inner),
-            }
-        }
-    }
-
-    impl<T: EchoServiceServer> Clone for EchoServiceServerImpl<T> {
-        fn clone(&self) -> Self {
-            Self {
-                inner: self.inner.clone(),
-            }
-        }
-    }
-
-    impl<T: EchoServiceServer> tonic::server::NamedService for EchoServiceServerImpl<T> {
-        const NAME: &'static str = "grpc_echo.v1.EchoService";
-    }
-
-    impl<T: EchoServiceServer>
-        tonic::codegen::Service<tonic::codegen::http::Request<tonic::body::BoxBody>>
-        for EchoServiceServerImpl<T>
-    {
-        type Response = tonic::codegen::http::Response<tonic::body::BoxBody>;
-        type Error = std::convert::Infallible;
-        type Future =
-            Pin<Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>>;
-
-        fn poll_ready(
-            &mut self,
-            _cx: &mut std::task::Context<'_>,
-        ) -> std::task::Poll<Result<(), Self::Error>> {
-            std::task::Poll::Ready(Ok(()))
-        }
-
-        fn call(
-            &mut self,
-            req: tonic::codegen::http::Request<tonic::body::BoxBody>,
-        ) -> Self::Future {
-            let inner = self.inner.clone();
-            Box::pin(async move {
-                let path = req.uri().path().to_string();
-                match path.as_str() {
-                    "/grpc_echo.v1.EchoService/Echo" => {
-                        let codec =
-                            tonic::codec::ProstCodec::<EchoResponse, EchoRequest>::default();
-                        let mut grpc = tonic::server::Grpc::new(codec);
-                        struct Handler<T>(std::sync::Arc<T>);
-                        #[tonic::async_trait]
-                        impl<T: EchoServiceServer> tonic::server::UnaryService<EchoRequest> for Handler<T> {
-                            type Response = EchoResponse;
-                            type Future = Pin<
-                                Box<
-                                    dyn std::future::Future<
-                                            Output = Result<Response<Self::Response>, Status>,
-                                        > + Send,
-                                >,
-                            >;
-                            fn call(&mut self, req: Request<EchoRequest>) -> Self::Future {
-                                let inner = self.0.clone();
-                                Box::pin(async move { inner.echo(req).await })
-                            }
-                        }
-                        let resp = grpc.unary(Handler(inner), req).await;
-                        Ok(resp)
-                    }
-                    "/grpc_echo.v1.EchoService/ServerStreamEcho" => {
-                        let codec =
-                            tonic::codec::ProstCodec::<EchoResponse, StreamEchoRequest>::default();
-                        let mut grpc = tonic::server::Grpc::new(codec);
-                        struct Handler<T>(std::sync::Arc<T>);
-                        #[tonic::async_trait]
-                        impl<T: EchoServiceServer>
-                            tonic::server::ServerStreamingService<StreamEchoRequest>
-                            for Handler<T>
-                        {
-                            type Response = EchoResponse;
-                            type ResponseStream = T::ServerStreamEchoStream;
-                            type Future = Pin<
-                                Box<
-                                    dyn std::future::Future<
-                                            Output = Result<Response<Self::ResponseStream>, Status>,
-                                        > + Send,
-                                >,
-                            >;
-                            fn call(&mut self, req: Request<StreamEchoRequest>) -> Self::Future {
-                                let inner = self.0.clone();
-                                Box::pin(async move { inner.server_stream_echo(req).await })
-                            }
-                        }
-                        let resp = grpc.server_streaming(Handler(inner), req).await;
-                        Ok(resp)
-                    }
-                    "/grpc_echo.v1.EchoService/BidiStreamEcho" => {
-                        let codec =
-                            tonic::codec::ProstCodec::<EchoResponse, EchoRequest>::default();
-                        let mut grpc = tonic::server::Grpc::new(codec);
-                        struct Handler<T>(std::sync::Arc<T>);
-                        #[tonic::async_trait]
-                        impl<T: EchoServiceServer> tonic::server::StreamingService<EchoRequest> for Handler<T> {
-                            type Response = EchoResponse;
-                            type ResponseStream = T::BidiStreamEchoStream;
-                            type Future = Pin<
-                                Box<
-                                    dyn std::future::Future<
-                                            Output = Result<Response<Self::ResponseStream>, Status>,
-                                        > + Send,
-                                >,
-                            >;
-                            fn call(
-                                &mut self,
-                                req: Request<Streaming<EchoRequest>>,
-                            ) -> Self::Future {
-                                let inner = self.0.clone();
-                                Box::pin(async move { inner.bidi_stream_echo(req).await })
-                            }
-                        }
-                        let resp = grpc.streaming(Handler(inner), req).await;
-                        Ok(resp)
-                    }
-                    _ => Ok(tonic::codegen::http::Response::builder()
-                        .status(tonic::codegen::http::StatusCode::from_u16(404).unwrap())
-                        .body(tonic::body::empty_body())
-                        .unwrap()),
-                }
-            })
-        }
-    }
-}
-
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let port: u16 = std::env::args()
@@ -300,18 +117,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let addr: SocketAddr = format!("127.0.0.1:{}", port).parse()?;
 
-    let (mut reporter, health_service) = health_reporter();
+    let (reporter, health_service) = health_reporter();
     reporter
         .set_service_status("", ServingStatus::Serving)
         .await;
-
-    let echo_service = echo_service_trait::EchoServiceServerImpl::new(EchoService);
 
     eprintln!("gRPC echo+health server listening on {}", addr);
 
     Server::builder()
         .add_service(health_service)
-        .add_service(echo_service)
+        .add_service(EchoServiceServer::new(EchoService))
         .serve(addr)
         .await?;
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -19,7 +19,7 @@ tokio-util = { version = "0.7", features = ["io", "codec"] }
 quinn = { version = "0.11", default-features = false, features = ["log", "platform-verifier", "runtime-tokio", "rustls-aws-lc-rs", "bloom"] }
 rustls = { version = "0.23", features = ["aws_lc_rs"] }
 tokio-rustls = "0.26"
-webpki-roots = "0.26"
+webpki-roots = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 anyhow = "1.0"

--- a/docs/rust-1.95-and-deps-upgrade-notes.md
+++ b/docs/rust-1.95-and-deps-upgrade-notes.md
@@ -15,8 +15,21 @@ Last checked: 2026-04-18
   - `if let` guards in `server/hot_reload.rs` (notify event filter).
 - `bincode` path is obsolete — moved to `rkyv 0.8.15` in PR #25. The
   "Batch C: bincode" row below is now historical.
-- Remaining: Batch B (tonic/prost, notify, metrics-exporter-prometheus,
-  tokio-tungstenite, webpki-roots, socket2).
+- Batch B landed as a single branch (5 commits):
+  - `socket2 0.5 → 0.6`, `tokio-tungstenite 0.24 → 0.29`
+    (Message::Text now carries `Utf8Bytes`; updated ci-test-client).
+  - `metrics-exporter-prometheus 0.16 → 0.18` (API compatible).
+  - `notify 6.1 → 8.2` (cross-major; our usage in
+    `server/hot_reload.rs` stayed source-compatible).
+  - `webpki-roots 0.26 → 1.0` (cross-major; `TLS_SERVER_ROOTS` still
+    iterable; all three crate declarations moved together).
+  - `tonic 0.12 → 0.14`, `prost 0.13 → 0.14`, `tonic-health 0.14`:
+    replaced 250 lines of hand-written gRPC glue in ci-helpers with
+    `tonic-prost-build` + `tonic::include_proto!`, since tonic 0.14
+    made `tonic::body::BoxBody` private and moved prost integration
+    into `tonic-prost` / `tonic-prost-build`.
+- Only Batch C item remaining is `sha2 0.10 → 0.11`, which the notes
+  already recommended deferring.
 
 ## Scope
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -39,7 +39,7 @@ http-body-util = "0.1"
 async-trait = "0.1"
 tokio-rustls = "0.26"
 metrics = "0.24"
-metrics-exporter-prometheus = "0.16"
+metrics-exporter-prometheus = "0.18"
 arc-swap = "1.9"
 notify = { version = "6.1", features = ["macos_kqueue"] }
 figment = { version = "0.10", features = ["yaml", "env"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { version = "1.52", features = ["full", "io-util"] }
 tokio-util = "0.7"
 quinn = { version = "0.11", default-features = false, features = ["log", "platform-verifier", "runtime-tokio", "rustls-aws-lc-rs", "bloom"] }
 rustls = { version = "0.23", features = ["aws_lc_rs"] }
-webpki-roots = "0.26"
+webpki-roots = "1.0"
 serde_yaml = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -41,7 +41,7 @@ tokio-rustls = "0.26"
 metrics = "0.24"
 metrics-exporter-prometheus = "0.18"
 arc-swap = "1.9"
-notify = { version = "6.1", features = ["macos_kqueue"] }
+notify = { version = "8.2", features = ["macos_kqueue"] }
 figment = { version = "0.10", features = ["yaml", "env"] }
 parking_lot = "0.12"
 uuid = { version = "1", features = ["v4"] }

--- a/tunnel-lib/Cargo.toml
+++ b/tunnel-lib/Cargo.toml
@@ -32,7 +32,7 @@ tokio-rustls = "0.26"
 webpki-roots = "0.26"
 hpack = "0.3"
 libc = "0.2"
-socket2 = { version = "0.5", features = ["all"] }
+socket2 = { version = "0.6", features = ["all"] }
 pin-project-lite = "0.2"
 
 [dev-dependencies]

--- a/tunnel-lib/Cargo.toml
+++ b/tunnel-lib/Cargo.toml
@@ -29,7 +29,7 @@ crossbeam-utils = "0.8"
 dashmap = "6.1"
 parking_lot = "0.12"
 tokio-rustls = "0.26"
-webpki-roots = "0.26"
+webpki-roots = "1.0"
 hpack = "0.3"
 libc = "0.2"
 socket2 = { version = "0.6", features = ["all"] }


### PR DESCRIPTION
## Summary

Lands **all of Batch B** from \`docs/rust-1.95-and-deps-upgrade-notes.md\` as 5 focused commits on a single branch (one commit per logical upgrade, so \`git bisect\` and cherry-pick stay clean).

After this PR, the only remaining item from the original notes is \`sha2 0.10 → 0.11\`, which was already recommended to defer.

## Commits (review in order)

1. **socket2 0.5 → 0.6 + tokio-tungstenite 0.24 → 0.29**  
   tungstenite's \`Message::Text\` now carries \`Utf8Bytes\` instead of \`String\` — one \`.into()\` added in \`ci_test_client.rs\`. socket2 usage in \`transport/listener.rs\` unchanged.

2. **metrics-exporter-prometheus 0.16 → 0.18**  
   API compatible; only \`Cargo.toml\` touched.

3. **notify 6.1 → 8.2** (cross-major)  
   \`RecommendedWatcher::new\` / \`notify::Config::default()\` / \`EventKind::{Create, Modify, Remove}\` / \`"macos_kqueue"\` feature all still compile.

4. **webpki-roots 0.26 → 1.0** (cross-major)  
   \`TLS_SERVER_ROOTS\` still iterable. All three Cargo.toml declarations bumped together so \`Cargo.lock\` resolves to a single v1 copy.

5. **tonic 0.12 → 0.14 + prost 0.13 → 0.14 + tonic-health 0.14**  
   tonic 0.14 moved prost integration into \`tonic-prost\` / \`tonic-prost-build\` and made \`tonic::body::BoxBody\` private. Our old hand-rolled gRPC glue no longer compiled, so this commit introduces \`tonic-prost-build\` as a build-dep and generates the \`EchoService\` stubs from the already-existing \`proto/grpc_echo.proto\`.  
   Net: **-250 / +31 lines** in \`ci-helpers\`. The crate now depends on tonic purely through the supported high-level surface, which makes future tonic upgrades trivial.

## Trade-offs

- \`notify 6 → 8\`: macOS kqueue event coalescing behaviour should be sanity-checked in staging, even though the source compiles unchanged.
- \`webpki-roots 0 → 1\`: root cert bundle is newer; egress TLS to external upstreams worth a spot-check after rollout.
- \`tonic 0.14\`: the manual gRPC glue is gone. If we ever need extremely low-level control over the codec/path, we'd have to add it back — but right now none of that flexibility was being used.

## Test plan

- [x] \`cargo check --workspace\` — clean (on 1.95.0)
- [x] \`cargo build --workspace\` — clean
- [x] \`cargo test --workspace\` — all 63 tunnel-lib tests pass; no other crate has unit tests
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — 0 warning
- [ ] CI integration (grpc-echo / grpc-server-stream / grpc-bidi-stream) — should pass given the generated client exercises the same wire protocol; watch CI output
- [ ] Staging smoke: config hot-reload fires (notify path); egress TLS handshake to an external upstream (webpki-roots); Prometheus metrics scrape succeeds (metrics-exporter-prometheus)

## Docs

\`docs/rust-1.95-and-deps-upgrade-notes.md\` updated with "Progress" section reflecting Batch B completion.