### PR TITLE
fix(ci-helpers): use protox for gRPC codegen; bump sha2 0.10 -> 0.11

### DIFF
--- a/ci-helpers/Cargo.toml
+++ b/ci-helpers/Cargo.toml
@@ -23,6 +23,7 @@ path = "src/ci_test_client.rs"
 
 [build-dependencies]
 tonic-prost-build = "0.14"
+protox = "0.9"
 
 [dependencies]
 tonic = { version = "0.14", features = ["tls-aws-lc", "tls-native-roots", "tls-webpki-roots"] }

--- a/ci-helpers/build.rs
+++ b/ci-helpers/build.rs
@@ -1,7 +1,8 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let file_descriptors = protox::compile(["proto/grpc_echo.proto"], ["proto"])?;
     tonic_prost_build::configure()
         .build_client(true)
         .build_server(true)
-        .compile_protos(&["proto/grpc_echo.proto"], &["proto"])?;
+        .compile_fds(file_descriptors)?;
     Ok(())
 }

--- a/tunnel-service/Cargo.toml
+++ b/tunnel-service/Cargo.toml
@@ -24,4 +24,4 @@ figment = { version = "0.10", features = ["yaml", "env"] }
 arc-swap = "1.9"
 subtle = "2"
 hex = "0.4"
-sha2 = "0.10"
+sha2 = "0.11"

--- a/tunnel-store/Cargo.toml
+++ b/tunnel-store/Cargo.toml
@@ -12,7 +12,7 @@ server-config = ["figment", "tunnel-lib"]
 [dependencies]
 async-trait = "0.1"
 anyhow = "1.0"
-sha2 = "0.10"
+sha2 = "0.11"
 subtle = "2"
 hex = "0.4"
 base64 = "0.22"


### PR DESCRIPTION
## Summary

Two small, independent fixes on one branch:

### 1. Switch ci-helpers gRPC codegen from protoc to protox

PR #27 introduced \`tonic-prost-build\`, which by default shells out to a system \`protoc\`. GitHub Actions runners do not ship it, so release builds were failing with:

\`\`\`
Error: Custom { kind: NotFound, error: \"Could not find \`protoc\`...\" }
error: failed to run custom build command for \`ci-helpers v0.1.0\`
\`\`\`

Use **protox** (pure-Rust protobuf compiler) to produce a \`FileDescriptorSet\` in \`build.rs\`, then feed it to \`tonic_prost_build::configure().compile_fds(...)\`. No external binary required, no CI workflow change needed.

### 2. sha2 0.10 → 0.11

Clears the last deferred entry in \`docs/rust-1.95-and-deps-upgrade-notes.md\`. Direct call sites (\`tunnel-store/src/token.rs\`: \`Sha256::digest(bytes)\`) are unchanged between 0.10 and 0.11 so no code edits. \`sqlx-core\` still pins sha2 0.10 transitively, so \`Cargo.lock\` carries two versions until sqlx publishes an update; not worth patching around.

## Test plan

- [x] \`cargo clean -p ci-helpers && cargo build -p ci-helpers\` — clean
- [x] \`cargo build --workspace\` — clean
- [x] \`cargo test --workspace\` — all pass (63 tunnel-lib tests)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — 0 warning
- [ ] CI release pipeline should now build ci-helpers without protoc