### PR TITLE
feat(plugin): ingress/egress plugin migration — PRs ②–⑥

### DIFF
--- a/client/app.rs
+++ b/client/app.rs
@@ -11,16 +11,18 @@ use tunnel_lib::proxy::peers::PeerKind;
 use tunnel_lib::proxy::tcp::UpstreamScheme;
 use tunnel_lib::{ClientConfig, HttpClientParams};
 
-/// One named upstream group: a list of pre-parsed `Target`s plus the
-/// `LoadBalancer` plugin that picks from them.
-struct UpstreamGroupPlugin {
-    targets: Vec<Target>,
+/// One named upstream group. `raw` is the source-of-truth address list in
+/// `scheme://host:port` form. `targets` is a parallel view built at config
+/// load time for the `LoadBalancer` plugin; the LB returns an index into the
+/// slice which we use directly into `raw`.
+struct UpstreamGroup {
     raw: Vec<String>,
+    targets: Vec<Target>,
     lb: Arc<dyn LoadBalancer>,
 }
 
 pub struct LocalProxyMap {
-    upstreams: HashMap<String, UpstreamGroupPlugin>,
+    upstreams: HashMap<String, UpstreamGroup>,
     resolver: Arc<dyn Resolver>,
     pub https_client: HttpsClient,
     pub h2c_client: H2cClient,
@@ -39,16 +41,20 @@ impl LocalProxyMap {
             let targets: Vec<Target> = raw
                 .iter()
                 .map(|addr| {
-                    let (scheme, connect_addr, _tls_host) = UpstreamScheme::from_address(addr);
-                    let (host, port) = split_host_port(&connect_addr);
-                    Target { host, port, scheme }
+                    let (scheme, _connect_addr, _tls_host) = UpstreamScheme::from_address(addr);
+                    let parsed = tunnel_lib::transport::addr::parse_upstream(addr);
+                    Target {
+                        host: parsed.host,
+                        port: parsed.port,
+                        scheme,
+                    }
                 })
                 .collect();
             upstreams.insert(
                 upstream.name.clone(),
-                UpstreamGroupPlugin {
-                    targets,
+                UpstreamGroup {
                     raw,
+                    targets,
                     lb: lb.clone(),
                 },
             );
@@ -68,38 +74,25 @@ impl LocalProxyMap {
     pub fn get_local_address(&self, proxy_name: &str, client_addr: SocketAddr) -> Option<String> {
         let group = self.upstreams.get(proxy_name)?;
         let ctx = PickCtx { client_addr };
-        let target = group.lb.pick(&group.targets, &ctx)?;
-        let idx = group
-            .targets
-            .iter()
-            .position(|t| std::ptr::eq(t, target))?;
+        let idx = group.lb.pick(&group.targets, &ctx)?;
         let addr = group.raw.get(idx).cloned()?;
         debug!(proxy_name = %proxy_name, server = %addr, "upstream selected");
         Some(addr)
     }
 
-    /// Resolve `connect_addr_str` (host:port) to a single `SocketAddr` via
-    /// the `Resolver` plugin.
+    /// Resolve `connect_addr_str` (either an IP literal `host:port` or a
+    /// hostname `host:port`) to a single `SocketAddr` via the `Resolver`
+    /// plugin.
     pub async fn resolve_addr(&self, connect_addr_str: &str) -> Result<SocketAddr> {
         if let Ok(addr) = connect_addr_str.parse::<SocketAddr>() {
             return Ok(addr);
         }
-        let (host, port) = split_host_port(connect_addr_str);
-        let addrs = self.resolver.resolve(&host, port).await?;
+        let parsed = tunnel_lib::transport::addr::parse_upstream(connect_addr_str);
+        let addrs = self.resolver.resolve(&parsed.host, parsed.port).await?;
         addrs
             .into_iter()
             .next()
             .ok_or_else(|| anyhow!("no resolved IP for {}", connect_addr_str))
-    }
-}
-
-fn split_host_port(addr: &str) -> (String, u16) {
-    match addr.rsplit_once(':') {
-        Some((host, port_str)) => {
-            let port = port_str.parse::<u16>().unwrap_or(0);
-            (host.to_string(), port)
-        }
-        None => (addr.to_string(), 0),
     }
 }
 

--- a/client/app.rs
+++ b/client/app.rs
@@ -1,79 +1,105 @@
 use anyhow::{anyhow, Context, Result};
-use dashmap::DashMap;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
 use tracing::{debug, info};
 pub use tunnel_lib::egress::http::{H2cClient, HttpsClient};
+use tunnel_lib::plugin::{LoadBalancer, PickCtx, Resolver, Target};
 use tunnel_lib::proxy::core::{Context as ProxyContext, Protocol, UpstreamResolver};
 use tunnel_lib::proxy::http::HttpPeer;
 use tunnel_lib::proxy::peers::PeerKind;
-use tunnel_lib::{ClientConfig, HttpClientParams, UpstreamGroup};
-struct CachedAddr {
-    addr: SocketAddr,
-    cached_at: Instant,
+use tunnel_lib::proxy::tcp::UpstreamScheme;
+use tunnel_lib::{ClientConfig, HttpClientParams};
+
+/// One named upstream group: a list of pre-parsed `Target`s plus the
+/// `LoadBalancer` plugin that picks from them.
+struct UpstreamGroupPlugin {
+    targets: Vec<Target>,
+    raw: Vec<String>,
+    lb: Arc<dyn LoadBalancer>,
 }
+
 pub struct LocalProxyMap {
-    upstreams: HashMap<String, UpstreamGroup>,
-    dns_cache: DashMap<String, CachedAddr>,
+    upstreams: HashMap<String, UpstreamGroupPlugin>,
+    resolver: Arc<dyn Resolver>,
     pub https_client: HttpsClient,
     pub h2c_client: H2cClient,
 }
+
 impl LocalProxyMap {
-    pub fn from_config(config: &ClientConfig, http_params: &HttpClientParams) -> Self {
+    pub fn from_config(
+        config: &ClientConfig,
+        http_params: &HttpClientParams,
+        lb: Arc<dyn LoadBalancer>,
+        resolver: Arc<dyn Resolver>,
+    ) -> Self {
         let mut upstreams = HashMap::new();
         for upstream in &config.upstreams {
-            let servers: Vec<String> = upstream.servers.iter().map(|s| s.address.clone()).collect();
-            upstreams.insert(upstream.name.clone(), UpstreamGroup::new(servers));
+            let raw: Vec<String> = upstream.servers.iter().map(|s| s.address.clone()).collect();
+            let targets: Vec<Target> = raw
+                .iter()
+                .map(|addr| {
+                    let (scheme, connect_addr, _tls_host) = UpstreamScheme::from_address(addr);
+                    let (host, port) = split_host_port(&connect_addr);
+                    Target { host, port, scheme }
+                })
+                .collect();
+            upstreams.insert(
+                upstream.name.clone(),
+                UpstreamGroupPlugin {
+                    targets,
+                    raw,
+                    lb: lb.clone(),
+                },
+            );
         }
         let https_client = tunnel_lib::create_https_client_with(http_params);
         let h2c_client = tunnel_lib::create_h2c_client_with(http_params);
         Self {
             upstreams,
-            dns_cache: DashMap::new(),
+            resolver,
             https_client,
             h2c_client,
         }
     }
-    pub fn get_local_address(&self, proxy_name: &str) -> Option<String> {
+
+    /// Returns the raw upstream address (still in `scheme://host:port` form)
+    /// chosen by the `LoadBalancer` plugin for `proxy_name`.
+    pub fn get_local_address(&self, proxy_name: &str, client_addr: SocketAddr) -> Option<String> {
         let group = self.upstreams.get(proxy_name)?;
-        let server = group.next()?;
-        debug!(proxy_name = %proxy_name, server = %server, "upstream selected");
-        Some(server.clone())
+        let ctx = PickCtx { client_addr };
+        let target = group.lb.pick(&group.targets, &ctx)?;
+        let idx = group
+            .targets
+            .iter()
+            .position(|t| std::ptr::eq(t, target))?;
+        let addr = group.raw.get(idx).cloned()?;
+        debug!(proxy_name = %proxy_name, server = %addr, "upstream selected");
+        Some(addr)
     }
-    /// Resolve `connect_addr_str` to a `SocketAddr`, using a lazy DNS cache.
-    /// IP addresses are parsed directly. Hostnames are looked up once and cached.
+
+    /// Resolve `connect_addr_str` (host:port) to a single `SocketAddr` via
+    /// the `Resolver` plugin.
     pub async fn resolve_addr(&self, connect_addr_str: &str) -> Result<SocketAddr> {
-        const DNS_CACHE_TTL: Duration = Duration::from_secs(30);
         if let Ok(addr) = connect_addr_str.parse::<SocketAddr>() {
             return Ok(addr);
         }
-        if let Some(cached) = self.dns_cache.get(connect_addr_str) {
-            if cached.cached_at.elapsed() < DNS_CACHE_TTL {
-                return Ok(cached.addr);
-            }
-        }
-        let mut addrs = tokio::net::lookup_host(connect_addr_str)
-            .await
-            .map_err(|e| {
-                anyhow!(
-                    "failed to resolve upstream address {}: {}",
-                    connect_addr_str,
-                    e
-                )
-            })?;
-        let addr = addrs
+        let (host, port) = split_host_port(connect_addr_str);
+        let addrs = self.resolver.resolve(&host, port).await?;
+        addrs
+            .into_iter()
             .next()
-            .ok_or_else(|| anyhow!("no resolved IP for {}", connect_addr_str))?;
-        self.dns_cache.insert(
-            connect_addr_str.to_string(),
-            CachedAddr {
-                addr,
-                cached_at: Instant::now(),
-            },
-        );
-        Ok(addr)
+            .ok_or_else(|| anyhow!("no resolved IP for {}", connect_addr_str))
+    }
+}
+
+fn split_host_port(addr: &str) -> (String, u16) {
+    match addr.rsplit_once(':') {
+        Some((host, port_str)) => {
+            let port = port_str.parse::<u16>().unwrap_or(0);
+            (host.to_string(), port)
+        }
+        None => (addr.to_string(), 0),
     }
 }
 
@@ -94,9 +120,8 @@ impl UpstreamResolver for ClientApp {
             .ok_or_else(|| anyhow!("missing routing info in context"))?;
         let upstream_addr = self
             .map
-            .get_local_address(&routing.proxy_name)
+            .get_local_address(&routing.proxy_name, context.client_addr)
             .ok_or_else(|| anyhow::anyhow!("no upstream for proxy_name: {}", routing.proxy_name))?;
-        use tunnel_lib::proxy::tcp::UpstreamScheme;
         let (scheme, connect_addr_str, tls_host) = UpstreamScheme::from_address(&upstream_addr);
         let is_https = scheme.requires_tls();
         let http_scheme = if is_https { "https" } else { "http" };

--- a/client/main.rs
+++ b/client/main.rs
@@ -24,6 +24,7 @@ mod config;
 mod conn_pool;
 mod connect;
 mod entry;
+mod plugins;
 mod pool;
 mod proxy;
 use app::LocalProxyMap;
@@ -303,9 +304,15 @@ pub(crate) async fn run_client(
         upstreams = resp.config.upstreams.len(),
         "Login successful, config received"
     );
+    let lb: Arc<dyn tunnel_lib::plugin::LoadBalancer> =
+        Arc::new(plugins::lb_round_robin::RoundRobinLb::new());
+    let resolver: Arc<dyn tunnel_lib::plugin::Resolver> =
+        Arc::new(plugins::resolver_cached::CachedResolver::new());
     let proxy_map = Arc::new(LocalProxyMap::from_config(
         &resp.config,
         &tunnel_lib::HttpClientParams::from(&config.http_pool),
+        lb,
+        resolver,
     ));
     let session_cancel = CancellationToken::new();
     let tcp_params = tunnel_lib::TcpParams::from(&config.tcp);

--- a/client/plugins/lb_round_robin/mod.rs
+++ b/client/plugins/lb_round_robin/mod.rs
@@ -5,8 +5,7 @@ use tunnel_lib::plugin::{LoadBalancer, PickCtx, Target};
 /// Round-robin load balancer.
 ///
 /// Stateful — holds a per-instance counter. Power-of-two list lengths use a
-/// bitmask; other sizes fall back to modulo. Matches the behaviour of the
-/// now-removed `UpstreamGroup::next`.
+/// bitmask; other sizes fall back to modulo.
 pub struct RoundRobinLb {
     counter: AtomicUsize,
 }
@@ -26,7 +25,7 @@ impl Default for RoundRobinLb {
 }
 
 impl LoadBalancer for RoundRobinLb {
-    fn pick<'a>(&self, targets: &'a [Target], _ctx: &PickCtx) -> Option<&'a Target> {
+    fn pick(&self, targets: &[Target], _ctx: &PickCtx) -> Option<usize> {
         if targets.is_empty() {
             return None;
         }
@@ -37,7 +36,7 @@ impl LoadBalancer for RoundRobinLb {
         } else {
             raw % len
         };
-        targets.get(idx)
+        Some(idx)
     }
 }
 
@@ -61,10 +60,10 @@ mod tests {
         let ctx = PickCtx {
             client_addr: "127.0.0.1:1".parse().unwrap(),
         };
-        let picks: Vec<&str> = (0..6)
-            .map(|_| lb.pick(&targets, &ctx).unwrap().host.as_str())
+        let idxs: Vec<usize> = (0..6)
+            .map(|_| lb.pick(&targets, &ctx).unwrap())
             .collect();
-        assert_eq!(picks, vec!["a", "b", "c", "a", "b", "c"]);
+        assert_eq!(idxs, vec![0, 1, 2, 0, 1, 2]);
     }
 
     #[test]

--- a/client/plugins/lb_round_robin/mod.rs
+++ b/client/plugins/lb_round_robin/mod.rs
@@ -1,0 +1,78 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use tunnel_lib::plugin::{LoadBalancer, PickCtx, Target};
+
+/// Round-robin load balancer.
+///
+/// Stateful — holds a per-instance counter. Power-of-two list lengths use a
+/// bitmask; other sizes fall back to modulo. Matches the behaviour of the
+/// now-removed `UpstreamGroup::next`.
+pub struct RoundRobinLb {
+    counter: AtomicUsize,
+}
+
+impl RoundRobinLb {
+    pub fn new() -> Self {
+        Self {
+            counter: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl Default for RoundRobinLb {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LoadBalancer for RoundRobinLb {
+    fn pick<'a>(&self, targets: &'a [Target], _ctx: &PickCtx) -> Option<&'a Target> {
+        if targets.is_empty() {
+            return None;
+        }
+        let raw = self.counter.fetch_add(1, Ordering::Relaxed);
+        let len = targets.len();
+        let idx = if len.is_power_of_two() {
+            raw & (len - 1)
+        } else {
+            raw % len
+        };
+        targets.get(idx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tunnel_lib::proxy::tcp::UpstreamScheme;
+
+    fn target(host: &str) -> Target {
+        Target {
+            host: host.to_string(),
+            port: 80,
+            scheme: UpstreamScheme::Http,
+        }
+    }
+
+    #[test]
+    fn round_robin_rotates_through_targets() {
+        let lb = RoundRobinLb::new();
+        let targets = vec![target("a"), target("b"), target("c")];
+        let ctx = PickCtx {
+            client_addr: "127.0.0.1:1".parse().unwrap(),
+        };
+        let picks: Vec<&str> = (0..6)
+            .map(|_| lb.pick(&targets, &ctx).unwrap().host.as_str())
+            .collect();
+        assert_eq!(picks, vec!["a", "b", "c", "a", "b", "c"]);
+    }
+
+    #[test]
+    fn round_robin_empty_returns_none() {
+        let lb = RoundRobinLb::new();
+        let ctx = PickCtx {
+            client_addr: "127.0.0.1:1".parse().unwrap(),
+        };
+        assert!(lb.pick(&[], &ctx).is_none());
+    }
+}

--- a/client/plugins/mod.rs
+++ b/client/plugins/mod.rs
@@ -1,0 +1,2 @@
+pub mod lb_round_robin;
+pub mod resolver_cached;

--- a/client/plugins/resolver_cached/mod.rs
+++ b/client/plugins/resolver_cached/mod.rs
@@ -7,18 +7,22 @@ use std::time::{Duration, Instant};
 use tunnel_lib::plugin::Resolver;
 
 const DNS_CACHE_TTL: Duration = Duration::from_secs(30);
+const MAX_CACHE_ENTRIES: usize = 1024;
 
-struct CachedAddr {
-    addr: SocketAddr,
+struct CachedAddrs {
+    addrs: Vec<SocketAddr>,
     cached_at: Instant,
 }
 
 /// DNS resolver with a lazy 30-second cache.
 ///
-/// Wraps `tokio::net::lookup_host`. An IP literal bypasses the cache. On a
-/// miss or expiry, the first resolved address is stored.
+/// Wraps `tokio::net::lookup_host`. IP literals bypass the cache. On a miss
+/// or expiry all resolved addresses are stored so callers can do happy-eyeballs
+/// or retry across A/AAAA records. The cache is bounded at
+/// `MAX_CACHE_ENTRIES`; past the bound, a miss triggers eviction of every
+/// entry older than `DNS_CACHE_TTL` before the insert.
 pub struct CachedResolver {
-    cache: DashMap<String, CachedAddr>,
+    cache: DashMap<String, CachedAddrs>,
 }
 
 impl CachedResolver {
@@ -26,6 +30,12 @@ impl CachedResolver {
         Self {
             cache: DashMap::new(),
         }
+    }
+
+    fn evict_expired(&self) {
+        let now = Instant::now();
+        self.cache
+            .retain(|_, v| now.duration_since(v.cached_at) < DNS_CACHE_TTL);
     }
 }
 
@@ -38,7 +48,6 @@ impl Default for CachedResolver {
 #[async_trait]
 impl Resolver for CachedResolver {
     async fn resolve(&self, host: &str, port: u16) -> Result<Vec<SocketAddr>> {
-        // IP literals bypass the cache entirely.
         if let Ok(addr) = host.parse::<std::net::IpAddr>() {
             return Ok(vec![SocketAddr::new(addr, port)]);
         }
@@ -46,26 +55,29 @@ impl Resolver for CachedResolver {
         let cache_key = format!("{}:{}", host, port);
         if let Some(cached) = self.cache.get(&cache_key) {
             if cached.cached_at.elapsed() < DNS_CACHE_TTL {
-                return Ok(vec![cached.addr]);
+                return Ok(cached.addrs.clone());
             }
         }
 
-        let addr = {
-            let mut addrs = tokio::net::lookup_host(cache_key.as_str())
-                .await
-                .map_err(|e| anyhow!("failed to resolve {}: {}", cache_key, e))?;
-            addrs
-                .next()
-                .ok_or_else(|| anyhow!("no resolved IP for {}", cache_key))?
-        };
+        let addrs: Vec<SocketAddr> = tokio::net::lookup_host(cache_key.as_str())
+            .await
+            .map_err(|e| anyhow!("failed to resolve {}: {}", cache_key, e))?
+            .collect();
+        if addrs.is_empty() {
+            return Err(anyhow!("no resolved IP for {}", cache_key));
+        }
+
+        if self.cache.len() >= MAX_CACHE_ENTRIES {
+            self.evict_expired();
+        }
         self.cache.insert(
             cache_key,
-            CachedAddr {
-                addr,
+            CachedAddrs {
+                addrs: addrs.clone(),
                 cached_at: Instant::now(),
             },
         );
-        Ok(vec![addr])
+        Ok(addrs)
     }
 }
 
@@ -79,7 +91,6 @@ mod tests {
         let out = resolver.resolve("127.0.0.1", 8080).await.unwrap();
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].port(), 8080);
-        // No cache entry recorded for IP literals.
         assert!(resolver.cache.is_empty());
     }
 }

--- a/client/plugins/resolver_cached/mod.rs
+++ b/client/plugins/resolver_cached/mod.rs
@@ -37,6 +37,17 @@ impl CachedResolver {
         self.cache
             .retain(|_, v| now.duration_since(v.cached_at) < DNS_CACHE_TTL);
     }
+
+    fn evict_one_oldest(&self) {
+        let oldest_key = self
+            .cache
+            .iter()
+            .min_by_key(|entry| entry.value().cached_at)
+            .map(|entry| entry.key().clone());
+        if let Some(key) = oldest_key {
+            self.cache.remove(&key);
+        }
+    }
 }
 
 impl Default for CachedResolver {
@@ -67,8 +78,14 @@ impl Resolver for CachedResolver {
             return Err(anyhow!("no resolved IP for {}", cache_key));
         }
 
+        // A cache hit with expired data falls through here and re-inserts,
+        // so no extra `contains_key` guard is needed — we only over-evict in
+        // the rare case where the cache is actually full.
         if self.cache.len() >= MAX_CACHE_ENTRIES {
             self.evict_expired();
+            if self.cache.len() >= MAX_CACHE_ENTRIES {
+                self.evict_one_oldest();
+            }
         }
         self.cache.insert(
             cache_key,

--- a/client/plugins/resolver_cached/mod.rs
+++ b/client/plugins/resolver_cached/mod.rs
@@ -1,0 +1,86 @@
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use dashmap::DashMap;
+use std::net::SocketAddr;
+use std::time::{Duration, Instant};
+
+use tunnel_lib::plugin::Resolver;
+
+const DNS_CACHE_TTL: Duration = Duration::from_secs(30);
+
+struct CachedAddr {
+    addr: SocketAddr,
+    cached_at: Instant,
+}
+
+/// DNS resolver with a lazy 30-second cache.
+///
+/// Wraps `tokio::net::lookup_host`. An IP literal bypasses the cache. On a
+/// miss or expiry, the first resolved address is stored. Lifted verbatim from
+/// the inline logic in `client/app.rs:resolve_addr` (pre-PR ⑤).
+pub struct CachedResolver {
+    cache: DashMap<String, CachedAddr>,
+}
+
+impl CachedResolver {
+    pub fn new() -> Self {
+        Self {
+            cache: DashMap::new(),
+        }
+    }
+}
+
+impl Default for CachedResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Resolver for CachedResolver {
+    async fn resolve(&self, host: &str, port: u16) -> Result<Vec<SocketAddr>> {
+        // IP literals bypass the cache entirely.
+        if let Ok(addr) = host.parse::<std::net::IpAddr>() {
+            return Ok(vec![SocketAddr::new(addr, port)]);
+        }
+
+        let cache_key = format!("{}:{}", host, port);
+        if let Some(cached) = self.cache.get(&cache_key) {
+            if cached.cached_at.elapsed() < DNS_CACHE_TTL {
+                return Ok(vec![cached.addr]);
+            }
+        }
+
+        let addr = {
+            let mut addrs = tokio::net::lookup_host(cache_key.as_str())
+                .await
+                .map_err(|e| anyhow!("failed to resolve {}: {}", cache_key, e))?;
+            addrs
+                .next()
+                .ok_or_else(|| anyhow!("no resolved IP for {}", cache_key))?
+        };
+        self.cache.insert(
+            cache_key,
+            CachedAddr {
+                addr,
+                cached_at: Instant::now(),
+            },
+        );
+        Ok(vec![addr])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn ip_literal_resolves_without_cache() {
+        let resolver = CachedResolver::new();
+        let out = resolver.resolve("127.0.0.1", 8080).await.unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].port(), 8080);
+        // No cache entry recorded for IP literals.
+        assert!(resolver.cache.is_empty());
+    }
+}

--- a/client/plugins/resolver_cached/mod.rs
+++ b/client/plugins/resolver_cached/mod.rs
@@ -16,8 +16,7 @@ struct CachedAddr {
 /// DNS resolver with a lazy 30-second cache.
 ///
 /// Wraps `tokio::net::lookup_host`. An IP literal bypasses the cache. On a
-/// miss or expiry, the first resolved address is stored. Lifted verbatim from
-/// the inline logic in `client/app.rs:resolve_addr` (pre-PR ⑤).
+/// miss or expiry, the first resolved address is stored.
 pub struct CachedResolver {
     cache: DashMap<String, CachedAddr>,
 }

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,18 +1,22 @@
 # Ingress / Egress 插件化设计(v2)
 
-> 状态:**进行中** — PR ① 已合入(trait 骨架),PR ②–⑥ 待实施。
-> 最后更新:2026-04-19
+> 状态:**已完成** — PR ①–⑥ 全部落地,整体作为一个 PR 提交。
+> 最后更新:2026-04-20
 > v2 变更:参考 Cloudflare Pingora 架构重新设计,改"probe 竞争"为"phase 串行",拆 PluginCtx 为 Server/Egress 两个上下文,补全 phase 短路语义。
 >
 > **实施进度**
 > | PR | 内容 | 状态 |
 > |---|---|---|
 > | ① | `tunnel-lib/src/plugin/` trait 骨架(9 个文件,7 个 smoke tests) | ✅ 已合入 |
-> | ② | Ingress handler 插件化 + `IngressDispatcher`(影子迁移) | 🔜 待实施 |
-> | ③ | `RouteResolver` 插件化(VhostResolver + StaticPortResolver) | 🔜 待实施 |
-> | ④ | `MetricsSink` 插件化(PrometheusSink + NoopSink)+ 删 legacy 分支 | 🔜 待实施 |
-> | ⑤ | Egress 侧插件化(LoadBalancer + UpstreamDialer + Resolver) | 🔜 待实施 |
-> | ⑥ | 配置层接入 `ingress_plugins`/`egress_plugins` + 最终清理 | 🔜 待实施 |
+> | ② | Ingress handler 插件化 + `IngressDispatcher`(影子迁移) | ✅ 已合入 |
+> | ③ | `RouteResolver` 插件化(VhostPlugin + `NoRouteResolver` 兜底) | ✅ 已合入 |
+> | ④ | `MetricsSink` 插件化(PrometheusSink + NoopSink) | ✅ 已合入 |
+> | ⑤ | Egress 侧插件化(`RoundRobinLb` + `CachedResolver`;`UpstreamDialer` 沿用既有 `UpstreamResolver`/`PeerKind` 抽象) | ✅ 已合入 |
+> | ⑥ | 删除 `use_plugin_stack` 与 legacy HTTP dispatcher(~390 行) | ✅ 已合入 |
+>
+> **实施中的范围调整**:
+> - 配置驱动的 plugin 名字查表(`ingress_plugins: [...]`)未做 —— 当前每个 seam 只有一个实现,把字符串查表放进去属于过度抽象。等某个 seam 出现第二个实现时再加。
+> - `UpstreamDialer` trait 保留在 `tunnel-lib/src/plugin/egress.rs` 以保持对称性,但暂未用它替换 `client/app.rs` 的 `UpstreamResolver::upstream_peer` —— 后者已经是 trait 抽象,再套一层只会重复 dispatch 表。参见 §4.12 "Upstream Peer:不动"。
 
 ---
 

--- a/server/handlers/http.rs
+++ b/server/handlers/http.rs
@@ -50,17 +50,20 @@ pub async fn run_http_accept_loop(
                 metrics::tcp_connection_opened();
                 let result = if let Some(disp) = dispatcher {
                     // ── plugin stack path ──────────────────────────────────
-                    let svc = crate::tunnel_service::DefaultTunnelService;
+                    let metrics_sink = state.plugin_registry
+                        .as_ref()
+                        .map(|r| r.metrics_sink.clone())
+                        .unwrap_or_else(|| Arc::new(tunnel_lib::plugin::NoopSink));
+                    let svc = crate::tunnel_service::DefaultTunnelService {
+                        metrics: metrics_sink.clone(),
+                    };
                     let timeouts = Timeouts {
                         open_stream_ms: state.config.server.open_stream_timeout_ms,
                         ..Timeouts::default()
                     };
                     let mut ctx = ServerCtx::new(
                         peer_addr,
-                        state.plugin_registry
-                            .as_ref()
-                            .map(|r| r.metrics_sink.clone())
-                            .unwrap_or_else(|| Arc::new(tunnel_lib::plugin::NoopSink)),
+                        metrics_sink,
                         Arc::new(state.tcp_params.clone()),
                         state.overload_limits.clone(),
                         timeouts,

--- a/server/handlers/http.rs
+++ b/server/handlers/http.rs
@@ -23,11 +23,12 @@ pub async fn run_http_accept_loop(
     let emfile_backoff = Duration::from_millis(state.config.server.overload.emfile_backoff_ms);
     info!(addr = %addr, "http accept loop started");
 
-    // Pre-build dispatcher if plugin stack is enabled.
+    // Pre-build dispatcher if plugin stack is enabled. The dispatcher is
+    // keyed to this listener's port so Phase 4 route lookup uses it directly.
     let dispatcher: Option<Arc<IngressDispatcher>> =
         if state.use_plugin_stack {
             state.plugin_registry.as_ref().map(|reg| {
-                Arc::new(IngressDispatcher::new(reg.clone()))
+                Arc::new(IngressDispatcher::new(reg.clone(), port))
             })
         } else {
             None
@@ -49,9 +50,7 @@ pub async fn run_http_accept_loop(
                 metrics::tcp_connection_opened();
                 let result = if let Some(disp) = dispatcher {
                     // ── plugin stack path ──────────────────────────────────
-                    let svc = crate::tunnel_service::DefaultTunnelService {
-                        routing: state.routing.clone(),
-                    };
+                    let svc = crate::tunnel_service::DefaultTunnelService;
                     let timeouts = Timeouts {
                         open_stream_ms: state.config.server.open_stream_timeout_ms,
                         ..Timeouts::default()
@@ -66,19 +65,10 @@ pub async fn run_http_accept_loop(
                         state.overload_limits.clone(),
                         timeouts,
                     );
-                    // listener_port is not carried in peer_addr; pass via RouteCtx
-                    // by stashing it in a thread-local or passing through ctx.
-                    // For now, encode port in a wrapper via a simple ctx extension:
                     ctx.timing.accepted_at = std::time::Instant::now();
-                    // We need the port in RouteCtx — store it in a side-channel
-                    // by creating a thin wrapper service that knows the port.
-                    let svc_with_port = crate::tunnel_service::PortedTunnelService {
-                        inner: svc,
-                        port,
-                    };
-                    disp.dispatch(stream, &svc_with_port, &mut ctx).await
+                    disp.dispatch(stream, &svc, &mut ctx).await
                 } else {
-                    // ── legacy path (default until PR ④) ──────────────────
+                    // ── legacy path (default until PR ⑥) ──────────────────
                     handle_http_connection(state, stream, port).await
                 };
                 if let Err(e) = &result {

--- a/server/handlers/http.rs
+++ b/server/handlers/http.rs
@@ -48,6 +48,8 @@ pub async fn run_http_accept_loop(
                     Arc::new(state.tcp_params.clone()),
                     state.overload_limits.clone(),
                     timeouts,
+                    port,
+                    state.proxy_buffer_params.relay_buf_size,
                 );
                 ctx.timing.accepted_at = std::time::Instant::now();
 
@@ -66,4 +68,3 @@ pub async fn run_http_accept_loop(
     .await;
     Ok(())
 }
-

--- a/server/handlers/http.rs
+++ b/server/handlers/http.rs
@@ -6,6 +6,9 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
 use tunnel_lib::extract_host_from_http;
+use tunnel_lib::plugin::{IngressDispatcher, ServerCtx, Timeouts};
+#[allow(unused_imports)]
+use tunnel_lib::OverloadLimits;
 use tunnel_lib::proxy;
 use tunnel_lib::run_accept_worker;
 use tunnel_lib::RouteTarget;
@@ -19,20 +22,65 @@ pub async fn run_http_accept_loop(
     let addr = listener.local_addr()?;
     let emfile_backoff = Duration::from_millis(state.config.server.overload.emfile_backoff_ms);
     info!(addr = %addr, "http accept loop started");
+
+    // Pre-build dispatcher if plugin stack is enabled.
+    let dispatcher: Option<Arc<IngressDispatcher>> =
+        if state.use_plugin_stack {
+            state.plugin_registry.as_ref().map(|reg| {
+                Arc::new(IngressDispatcher::new(reg.clone()))
+            })
+        } else {
+            None
+        };
+
     run_accept_worker(
         listener,
         cancel,
         emfile_backoff,
         "http",
-        move |stream, _peer_addr| {
+        move |stream, peer_addr| {
             let state = state.clone();
+            let dispatcher = dispatcher.clone();
             tokio::task::spawn(async move {
                 if let Err(e) = state.tcp_params.apply(&stream) {
                     debug!(error = %e, "tcp_params.apply failed");
                     return;
                 }
                 metrics::tcp_connection_opened();
-                let result = handle_http_connection(state, stream, port).await;
+                let result = if let Some(disp) = dispatcher {
+                    // ── plugin stack path ──────────────────────────────────
+                    let svc = crate::tunnel_service::DefaultTunnelService {
+                        routing: state.routing.clone(),
+                    };
+                    let timeouts = Timeouts {
+                        open_stream_ms: state.config.server.open_stream_timeout_ms,
+                        ..Timeouts::default()
+                    };
+                    let mut ctx = ServerCtx::new(
+                        peer_addr,
+                        state.plugin_registry
+                            .as_ref()
+                            .map(|r| r.metrics_sink.clone())
+                            .unwrap_or_else(|| Arc::new(tunnel_lib::plugin::NoopSink)),
+                        Arc::new(state.tcp_params.clone()),
+                        state.overload_limits.clone(),
+                        timeouts,
+                    );
+                    // listener_port is not carried in peer_addr; pass via RouteCtx
+                    // by stashing it in a thread-local or passing through ctx.
+                    // For now, encode port in a wrapper via a simple ctx extension:
+                    ctx.timing.accepted_at = std::time::Instant::now();
+                    // We need the port in RouteCtx — store it in a side-channel
+                    // by creating a thin wrapper service that knows the port.
+                    let svc_with_port = crate::tunnel_service::PortedTunnelService {
+                        inner: svc,
+                        port,
+                    };
+                    disp.dispatch(stream, &svc_with_port, &mut ctx).await
+                } else {
+                    // ── legacy path (default until PR ④) ──────────────────
+                    handle_http_connection(state, stream, port).await
+                };
                 if let Err(e) = &result {
                     debug!(error = %e, "entry connection error");
                     metrics::request_completed("http", "error");

--- a/server/handlers/http.rs
+++ b/server/handlers/http.rs
@@ -2,16 +2,11 @@ use crate::{metrics, ServerState};
 use anyhow::Result;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::net::{TcpListener, TcpStream};
+use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
-use tunnel_lib::extract_host_from_http;
 use tunnel_lib::plugin::{IngressDispatcher, ServerCtx, Timeouts};
-#[allow(unused_imports)]
-use tunnel_lib::OverloadLimits;
-use tunnel_lib::proxy;
 use tunnel_lib::run_accept_worker;
-use tunnel_lib::RouteTarget;
 
 pub async fn run_http_accept_loop(
     listener: Arc<TcpListener>,
@@ -23,16 +18,8 @@ pub async fn run_http_accept_loop(
     let emfile_backoff = Duration::from_millis(state.config.server.overload.emfile_backoff_ms);
     info!(addr = %addr, "http accept loop started");
 
-    // Pre-build dispatcher if plugin stack is enabled. The dispatcher is
-    // keyed to this listener's port so Phase 4 route lookup uses it directly.
-    let dispatcher: Option<Arc<IngressDispatcher>> =
-        if state.use_plugin_stack {
-            state.plugin_registry.as_ref().map(|reg| {
-                Arc::new(IngressDispatcher::new(reg.clone(), port))
-            })
-        } else {
-            None
-        };
+    let dispatcher = Arc::new(IngressDispatcher::new(state.plugin_registry.clone(), port));
+    let metrics_sink = state.plugin_registry.metrics_sink.clone();
 
     run_accept_worker(
         listener,
@@ -42,38 +29,32 @@ pub async fn run_http_accept_loop(
         move |stream, peer_addr| {
             let state = state.clone();
             let dispatcher = dispatcher.clone();
+            let metrics_sink = metrics_sink.clone();
             tokio::task::spawn(async move {
                 if let Err(e) = state.tcp_params.apply(&stream) {
                     debug!(error = %e, "tcp_params.apply failed");
                     return;
                 }
                 metrics::tcp_connection_opened();
-                let result = if let Some(disp) = dispatcher {
-                    // ── plugin stack path ──────────────────────────────────
-                    let metrics_sink = state.plugin_registry
-                        .as_ref()
-                        .map(|r| r.metrics_sink.clone())
-                        .unwrap_or_else(|| Arc::new(tunnel_lib::plugin::NoopSink));
-                    let svc = crate::tunnel_service::DefaultTunnelService {
-                        metrics: metrics_sink.clone(),
-                    };
-                    let timeouts = Timeouts {
-                        open_stream_ms: state.config.server.open_stream_timeout_ms,
-                        ..Timeouts::default()
-                    };
-                    let mut ctx = ServerCtx::new(
-                        peer_addr,
-                        metrics_sink,
-                        Arc::new(state.tcp_params.clone()),
-                        state.overload_limits.clone(),
-                        timeouts,
-                    );
-                    ctx.timing.accepted_at = std::time::Instant::now();
-                    disp.dispatch(stream, &svc, &mut ctx).await
-                } else {
-                    // ── legacy path (default until PR ⑥) ──────────────────
-                    handle_http_connection(state, stream, port).await
+
+                let svc = crate::tunnel_service::DefaultTunnelService {
+                    metrics: metrics_sink.clone(),
                 };
+                let timeouts = Timeouts {
+                    open_stream_ms: state.config.server.open_stream_timeout_ms,
+                    ..Timeouts::default()
+                };
+                let mut ctx = ServerCtx::new(
+                    peer_addr,
+                    metrics_sink,
+                    Arc::new(state.tcp_params.clone()),
+                    state.overload_limits.clone(),
+                    timeouts,
+                );
+                ctx.timing.accepted_at = std::time::Instant::now();
+
+                let result = dispatcher.dispatch(stream, &svc, &mut ctx).await;
+
                 if let Err(e) = &result {
                     debug!(error = %e, "entry connection error");
                     metrics::request_completed("http", "error");
@@ -87,344 +68,4 @@ pub async fn run_http_accept_loop(
     .await;
     Ok(())
 }
-async fn handle_http_connection(
-    state: Arc<ServerState>,
-    stream: TcpStream,
-    port: u16,
-) -> Result<()> {
-    use tunnel_lib::detect_protocol_and_host;
-    use tunnel_lib::protocol::detect::extract_tls_sni;
-    let peer_addr = stream.peer_addr()?;
-    let pool = &state.peek_buf_pool;
-    let mut buf = pool.take();
-    let n = match stream.peek(&mut buf).await {
-        Ok(n) => n,
-        Err(e) => {
-            pool.put(buf);
-            return Err(e.into());
-        }
-    };
-    let is_tls = n > 0 && buf[0] == 0x16;
-    if is_tls {
-        let sni = extract_tls_sni(&buf[..n]);
-        pool.put(buf);
-        let host = sni.ok_or_else(|| anyhow::anyhow!("no SNI in TLS ClientHello"))?;
-        handle_tls_connection(state, stream, host, peer_addr, port).await
-    } else {
-        let (protocol, detected_host) = detect_protocol_and_host(&buf[..n]);
-        if protocol == tunnel_lib::proxy::core::Protocol::H2 {
-            pool.put(buf);
-            handle_plaintext_h2_connection(state, stream, peer_addr, port).await
-        } else {
-            let host = detected_host.or_else(|| extract_host_from_http(&buf[..n]));
-            let initial_data: Vec<u8> = buf[..n].to_vec();
-            pool.put(buf);
-            let host =
-                host.ok_or_else(|| anyhow::anyhow!("no Host header in plaintext request"))?;
-            handle_plaintext_h1_connection(
-                state,
-                stream,
-                host,
-                protocol,
-                peer_addr,
-                &initial_data,
-                port,
-            )
-            .await
-        }
-    }
-}
-fn lookup_route(state: &ServerState, port: u16, host: &str) -> Option<RouteTarget> {
-    state
-        .routing
-        .load()
-        .http_routers
-        .get(&port)
-        .and_then(|router| router.get(host))
-}
-async fn handle_tls_connection(
-    state: Arc<ServerState>,
-    stream: TcpStream,
-    host: String,
-    peer_addr: std::net::SocketAddr,
-    port: u16,
-) -> Result<()> {
-    use http_body_util::{BodyExt, Full};
-    use hyper::server::conn::http2::Builder as H2Builder;
-    use hyper::service::service_fn;
-    use hyper::{Request, Response};
-    use hyper_util::rt::TokioIo;
-    debug!(host = %host, "TLS connection detected, terminating");
-    let route = lookup_route(&state, port, &host)
-        .ok_or_else(|| anyhow::anyhow!("no route for host: {}", host))?;
-    let (group_id, proxy_name) = (route.group_id, route.proxy_name);
-    let server_config = tunnel_lib::infra::pki::get_or_create_server_config(&host)?;
-    let acceptor = tokio_rustls::TlsAcceptor::from(server_config);
-    let tls_stream = acceptor.accept(stream).await?;
-    info!("TLS terminated, serving H2 with authority rewriting");
-    let target_host = host.clone();
-    let src_addr = peer_addr.ip().to_string();
-    let src_port = peer_addr.port();
-    let selected = state
-        .registry
-        .select_client_for_group(&group_id)
-        .ok_or_else(|| anyhow::anyhow!("no client for group: {}", group_id))?;
-    let client_conn = selected.conn;
-    let sender_cache = tunnel_lib::new_h2_sender();
-    let service = service_fn(move |req: Request<hyper::body::Incoming>| {
-        let client_conn = client_conn.clone();
-        let sender_cache = sender_cache.clone();
-        let proxy_name = proxy_name.clone();
-        let target_host = target_host.clone();
-        let src_addr = src_addr.clone();
-        async move {
-            let (mut parts, body) = req.into_parts();
-            let mut uri_parts = parts.uri.clone().into_parts();
-            if let Ok(authority) = target_host.parse() {
-                uri_parts.authority = Some(authority);
-            }
-            parts.uri = hyper::Uri::from_parts(uri_parts).unwrap_or(parts.uri);
-            if let Ok(host_value) = target_host.parse() {
-                parts.headers.insert(hyper::header::HOST, host_value);
-            }
-            debug!(
-                "L7 Proxy: rewriting authority to {}, forwarding {} {}",
-                target_host, parts.method, parts.uri
-            );
-            let routing_info = tunnel_lib::RoutingInfo {
-                proxy_name: proxy_name.to_string(),
-                src_addr,
-                src_port,
-                protocol: tunnel_lib::proxy::core::Protocol::H2,
-                host: Some(target_host),
-            };
-            let boxed_body = body.map_err(std::io::Error::other).boxed();
-            let upstream_req = Request::from_parts(parts, boxed_body);
-            match tunnel_lib::forward_h2_request(&client_conn, &sender_cache, routing_info, upstream_req).await {
-                Ok(resp) => Ok::<_, hyper::Error>(resp),
-                Err(e) => {
-                    tracing::error!("L7 Proxy upstream error: {}", e);
-                    Ok(Response::builder()
-                        .status(502)
-                        .body(
-                            Full::new(bytes::Bytes::from("Bad Gateway"))
-                                .map_err(|_| unreachable!())
-                                .boxed(),
-                        )
-                        .unwrap())
-                }
-            }
-        }
-    });
-    let io = TokioIo::new(tls_stream);
-    H2Builder::new(hyper_util::rt::TokioExecutor::new())
-        .serve_connection(io, service)
-        .await
-        .map_err(|e| anyhow::anyhow!("H2 connection error: {}", e))?;
-    Ok(())
-}
-async fn handle_plaintext_h2_connection(
-    state: Arc<ServerState>,
-    stream: TcpStream,
-    peer_addr: std::net::SocketAddr,
-    port: u16,
-) -> Result<()> {
-    use http_body_util::{BodyExt, Full};
-    use hyper::server::conn::http2::Builder as H2Builder;
-    use hyper::service::service_fn;
-    use hyper::{Request, Response};
-    use hyper_util::rt::TokioIo;
-    use std::collections::HashMap;
-    use std::sync::Mutex;
-    debug!("plaintext H2 detected, using L7 proxy");
-    let src_addr = peer_addr.ip().to_string();
-    let src_port = peer_addr.port();
-    let h2_single_authority = state.config.server.h2_single_authority;
-    let first_authority: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
-    let route_cache: Arc<Mutex<HashMap<String, Option<RouteTarget>>>> =
-        Arc::new(Mutex::new(HashMap::new()));
-    let sender_cache: Arc<Mutex<HashMap<RouteTarget, (quinn::Connection, tunnel_lib::H2Sender)>>> =
-        Arc::new(Mutex::new(HashMap::new()));
-    let service = service_fn(move |req: Request<hyper::body::Incoming>| {
-        let state = state.clone();
-        let first_authority = first_authority.clone();
-        let route_cache = route_cache.clone();
-        let sender_cache = sender_cache.clone();
-        let src_addr = src_addr.clone();
-        async move {
-            let authority = req.uri().authority().map(|a| a.to_string()).or_else(|| {
-                req.headers()
-                    .get(hyper::header::HOST)
-                    .and_then(|h| h.to_str().ok())
-                    .map(|s| s.to_string())
-            });
-            let host = match authority {
-                Some(h) => h,
-                None => {
-                    return Ok(Response::builder()
-                        .status(400)
-                        .body(
-                            Full::new(bytes::Bytes::from("Missing authority"))
-                                .map_err(|_| unreachable!())
-                                .boxed(),
-                        )
-                        .unwrap());
-                }
-            };
-            let route_host = host.split(':').next().unwrap_or(&host).to_ascii_lowercase();
-            if h2_single_authority {
-                let mut fa = first_authority.lock().unwrap();
-                match fa.as_ref() {
-                    None => *fa = Some(route_host.clone()),
-                    Some(pinned) if pinned != &route_host => {
-                        return Ok(Response::builder()
-                            .status(421)
-                            .body(
-                                Full::new(bytes::Bytes::from("Misdirected Request"))
-                                    .map_err(|_| unreachable!())
-                                    .boxed(),
-                            )
-                            .unwrap());
-                    }
-                    Some(_) => {}
-                }
-            }
-            let route = {
-                let mut cache = route_cache.lock().unwrap();
-                cache
-                    .entry(route_host.clone())
-                    .or_insert_with(|| lookup_route(&state, port, &route_host))
-                    .clone()
-            };
-            let route = match route {
-                Some(r) => r,
-                None => {
-                    return Ok::<_, hyper::Error>(
-                        Response::builder()
-                            .status(404)
-                            .body(
-                                Full::new(bytes::Bytes::from("No route"))
-                                    .map_err(|_| unreachable!())
-                                    .boxed(),
-                            )
-                            .unwrap(),
-                    );
-                }
-            };
-            let (group_id, proxy_name) = (route.group_id.clone(), route.proxy_name.clone());
-            let (client_conn, h2_sender) = {
-                let mut guard = sender_cache.lock().unwrap();
-                if !guard.contains_key(&route) {
-                    if let Some(selected) =
-                        state.registry.select_client_for_group(&group_id)
-                    {
-                        guard.insert(route.clone(), (selected.conn, tunnel_lib::new_h2_sender()));
-                    }
-                }
-                match guard.get(&route) {
-                    Some(pair) => (pair.0.clone(), pair.1.clone()),
-                    None => {
-                        return Ok(Response::builder()
-                            .status(502)
-                            .body(
-                                Full::new(bytes::Bytes::from("No client available"))
-                                    .map_err(|_| unreachable!())
-                                    .boxed(),
-                            )
-                            .unwrap());
-                    }
-                }
-            };
-            let (parts, body) = req.into_parts();
-            debug!(
-                "L7 Proxy (plaintext H2): {} {} -> {}",
-                parts.method, parts.uri, host
-            );
-            let routing_info = tunnel_lib::RoutingInfo {
-                proxy_name: proxy_name.to_string(),
-                src_addr,
-                src_port,
-                protocol: tunnel_lib::proxy::core::Protocol::H2,
-                host: Some(host),
-            };
-            let boxed_body = body.map_err(std::io::Error::other).boxed();
-            let upstream_req = Request::from_parts(parts, boxed_body);
-            match tunnel_lib::forward_h2_request(&client_conn, &h2_sender, routing_info, upstream_req).await {
-                Ok(resp) => Ok::<_, hyper::Error>(resp),
-                Err(e) => {
-                    tracing::error!("L7 Proxy upstream error: {}", e);
-                    sender_cache.lock().unwrap().remove(&route);
-                    Ok(Response::builder()
-                        .status(502)
-                        .body(
-                            Full::new(bytes::Bytes::from("Bad Gateway"))
-                                .map_err(|_| unreachable!())
-                                .boxed(),
-                        )
-                        .unwrap())
-                }
-            }
-        }
-    });
-    let io = TokioIo::new(stream);
-    H2Builder::new(hyper_util::rt::TokioExecutor::new())
-        .serve_connection(io, service)
-        .await
-        .map_err(|e| anyhow::anyhow!("H2 connection error: {}", e))?;
-    Ok(())
-}
-async fn handle_plaintext_h1_connection(
-    state: Arc<ServerState>,
-    mut stream: TcpStream,
-    host: String,
-    protocol: tunnel_lib::proxy::core::Protocol,
-    peer_addr: std::net::SocketAddr,
-    initial_data: &[u8],
-    port: u16,
-) -> Result<()> {
-    use tokio::io::AsyncReadExt;
-    debug!(host = %host, protocol = ?protocol, "plaintext H1/WS, using byte-level forwarding");
-    let route = lookup_route(&state, port, &host)
-        .ok_or_else(|| anyhow::anyhow!("no route for host: {}", host))?;
-    let (group_id, proxy_name) = (route.group_id, route.proxy_name);
-    let selected = state
-        .registry
-        .select_client_for_group(&group_id)
-        .ok_or_else(|| anyhow::anyhow!("no client for group: {}", group_id))?;
-    let mut discard = vec![0u8; initial_data.len()];
-    stream.read_exact(&mut discard).await?;
-    let routing_info = tunnel_lib::RoutingInfo {
-        proxy_name: proxy_name.to_string(),
-        src_addr: peer_addr.ip().to_string(),
-        src_port: peer_addr.port(),
-        protocol,
-        host: Some(host),
-    };
-    let open_timeout = Duration::from_millis(state.config.server.open_stream_timeout_ms);
-    let _open_bi_guard = metrics::open_bi_begin(&selected.conn_id);
-    let opened = tunnel_lib::open_bi_guarded(
-        &selected.conn,
-        &selected.inflight,
-        &state.overload_limits,
-        open_timeout,
-        |elapsed, outcome| {
-            metrics::open_bi_observe_wait_ms(elapsed.as_secs_f64() * 1000.0);
-            if matches!(outcome, tunnel_lib::OpenBiOutcome::Timeout) {
-                metrics::open_bi_timeout();
-            }
-        },
-    )
-    .await?;
-    let mut send = opened.send;
-    let recv = opened.recv;
-    let _inflight_guard = opened.inflight;
-    tunnel_lib::send_routing_info(&mut send, &routing_info).await?;
-    proxy::forward_with_initial_data(
-        send,
-        recv,
-        stream,
-        initial_data,
-        state.proxy_buffer_params.relay_buf_size,
-    )
-    .await
-}
+

--- a/server/handlers/http.rs
+++ b/server/handlers/http.rs
@@ -37,9 +37,7 @@ pub async fn run_http_accept_loop(
                 }
                 metrics::tcp_connection_opened();
 
-                let svc = crate::tunnel_service::DefaultTunnelService {
-                    metrics: metrics_sink.clone(),
-                };
+                let svc = crate::tunnel_service::DefaultTunnelService;
                 let timeouts = Timeouts {
                     open_stream_ms: state.config.server.open_stream_timeout_ms,
                     ..Timeouts::default()

--- a/server/main.rs
+++ b/server/main.rs
@@ -412,6 +412,7 @@ async fn build_server_state(
             routing: routing.clone(),
         }));
         reg.set_metrics_sink(Arc::new(plugins::prometheus::PrometheusSink));
+        reg.validate_for_ingress()?;
         Arc::new(reg)
     };
 

--- a/server/main.rs
+++ b/server/main.rs
@@ -24,9 +24,11 @@ mod listener_mgr;
 mod local_auth;
 mod metrics;
 mod null_stores;
+mod plugins;
 mod registry;
 mod service;
 mod tunnel_handler;
+mod tunnel_service;
 use config::{
     ConfigSource, DbSource, FileSource, IngressMode, MergedSource, ServerConfigFile,
     ServerEgressUpstream, TunnelManagement,
@@ -116,6 +118,12 @@ pub struct ServerState {
     pub local_token_cache: Option<Arc<local_auth::LocalTokenCache>>,
     pub listeners: listener_mgr::ListenerManager,
     pub overload_limits: tunnel_lib::OverloadLimits,
+    /// Shadow-migration flag: when true, route HTTP connections through the
+    /// new plugin-based IngressDispatcher instead of the legacy if/else dispatcher.
+    /// Defaults to false; flip to true once integration tests pass.
+    pub use_plugin_stack: bool,
+    /// Plugin registry used by IngressDispatcher (None when use_plugin_stack=false).
+    pub plugin_registry: Option<Arc<tunnel_lib::plugin::PluginRegistry>>,
 }
 async fn build_stores(database_url: &str) -> Result<(Arc<dyn AuthStore>, Arc<dyn RuleStore>)> {
     let pool = tunnel_store::open_sqlite_pool(database_url).await?;
@@ -380,12 +388,37 @@ async fn build_server_state(
         max_concurrent_streams = max_streams,
         "overload protection resolved"
     );
+    let shared_registry = new_shared_registry();
+
+    // Build the plugin registry used by IngressDispatcher (PR ②).
+    // Populated with the four built-in ingress handlers; more plugins will be
+    // added as PRs ③–⑥ land.
+    let plugin_registry = {
+        use std::sync::Arc;
+        use tunnel_lib::plugin::PluginRegistry;
+        let mut reg = PluginRegistry::new();
+        reg.register_ingress_handler(Arc::new(plugins::tls::TlsHandler {
+            registry: shared_registry.clone(),
+        }));
+        reg.register_ingress_handler(Arc::new(plugins::h2c::H2cHandler {
+            registry: shared_registry.clone(),
+            single_authority: config.server.h2_single_authority,
+        }));
+        reg.register_ingress_handler(Arc::new(plugins::h1::H1Handler {
+            registry: shared_registry.clone(),
+        }));
+        reg.register_ingress_handler(Arc::new(plugins::tcp_pass::TcpPassHandler {
+            registry: shared_registry.clone(),
+        }));
+        Arc::new(reg)
+    };
+
     Ok(Arc::new(ServerState {
         tcp_params: tunnel_lib::TcpParams::from(&config.server.tcp),
         peek_buf_pool: PeekBufPool::new(proxy_buffer_params.peek_buf_size),
         proxy_buffer_params,
         routing: Arc::new(ArcSwap::from_pointee(initial_snapshot)),
-        registry: new_shared_registry(),
+        registry: shared_registry,
         config: Arc::new(config.clone()),
         auth_store,
         rule_store,
@@ -394,6 +427,8 @@ async fn build_server_state(
         local_token_cache,
         listeners: listener_mgr::ListenerManager::new(),
         overload_limits,
+        use_plugin_stack: false,
+        plugin_registry: Some(plugin_registry),
     }))
 }
 

--- a/server/main.rs
+++ b/server/main.rs
@@ -118,12 +118,10 @@ pub struct ServerState {
     pub local_token_cache: Option<Arc<local_auth::LocalTokenCache>>,
     pub listeners: listener_mgr::ListenerManager,
     pub overload_limits: tunnel_lib::OverloadLimits,
-    /// Shadow-migration flag: when true, route HTTP connections through the
-    /// new plugin-based IngressDispatcher instead of the legacy if/else dispatcher.
-    /// Defaults to false; flip to true once integration tests pass.
-    pub use_plugin_stack: bool,
-    /// Plugin registry used by IngressDispatcher (None when use_plugin_stack=false).
-    pub plugin_registry: Option<Arc<tunnel_lib::plugin::PluginRegistry>>,
+    /// Plugin registry used by `IngressDispatcher`; always present after
+    /// startup. Populated with ingress handlers, the vhost route resolver,
+    /// and the prometheus metrics sink in `build_server_state`.
+    pub plugin_registry: Arc<tunnel_lib::plugin::PluginRegistry>,
 }
 async fn build_stores(database_url: &str) -> Result<(Arc<dyn AuthStore>, Arc<dyn RuleStore>)> {
     let pool = tunnel_store::open_sqlite_pool(database_url).await?;
@@ -431,8 +429,7 @@ async fn build_server_state(
         local_token_cache,
         listeners: listener_mgr::ListenerManager::new(),
         overload_limits,
-        use_plugin_stack: true,
-        plugin_registry: Some(plugin_registry),
+        plugin_registry,
     }))
 }
 

--- a/server/main.rs
+++ b/server/main.rs
@@ -389,9 +389,9 @@ async fn build_server_state(
     let shared_registry = new_shared_registry();
     let routing = Arc::new(ArcSwap::from_pointee(initial_snapshot));
 
-    // Build the plugin registry used by IngressDispatcher (PR ②+③).
-    // Populated with the four built-in ingress handlers and the vhost route
-    // resolver; more plugins (metrics, egress, admission) land in PRs ④–⑥.
+    // Build the plugin registry used by IngressDispatcher. Populated with
+    // four ingress handlers, the vhost route resolver, and the prometheus
+    // metrics sink.
     let plugin_registry = {
         use tunnel_lib::plugin::PluginRegistry;
         let mut reg = PluginRegistry::new();

--- a/server/main.rs
+++ b/server/main.rs
@@ -413,6 +413,7 @@ async fn build_server_state(
         reg.set_route_resolver(Arc::new(plugins::vhost::VhostPlugin {
             routing: routing.clone(),
         }));
+        reg.set_metrics_sink(Arc::new(plugins::prometheus::PrometheusSink));
         Arc::new(reg)
     };
 
@@ -430,7 +431,7 @@ async fn build_server_state(
         local_token_cache,
         listeners: listener_mgr::ListenerManager::new(),
         overload_limits,
-        use_plugin_stack: false,
+        use_plugin_stack: true,
         plugin_registry: Some(plugin_registry),
     }))
 }

--- a/server/main.rs
+++ b/server/main.rs
@@ -395,11 +395,16 @@ async fn build_server_state(
     let plugin_registry = {
         use tunnel_lib::plugin::PluginRegistry;
         let mut reg = PluginRegistry::new();
+        let route_resolver: Arc<dyn tunnel_lib::plugin::RouteResolver> =
+            Arc::new(plugins::vhost::VhostPlugin {
+                routing: routing.clone(),
+            });
         reg.register_ingress_handler(Arc::new(plugins::tls::TlsHandler {
             registry: shared_registry.clone(),
         }));
         reg.register_ingress_handler(Arc::new(plugins::h2c::H2cHandler {
             registry: shared_registry.clone(),
+            route_resolver: route_resolver.clone(),
             single_authority: config.server.h2_single_authority,
         }));
         reg.register_ingress_handler(Arc::new(plugins::h1::H1Handler {
@@ -408,9 +413,7 @@ async fn build_server_state(
         reg.register_ingress_handler(Arc::new(plugins::tcp_pass::TcpPassHandler {
             registry: shared_registry.clone(),
         }));
-        reg.set_route_resolver(Arc::new(plugins::vhost::VhostPlugin {
-            routing: routing.clone(),
-        }));
+        reg.set_route_resolver(route_resolver);
         reg.set_metrics_sink(Arc::new(plugins::prometheus::PrometheusSink));
         reg.validate_for_ingress()?;
         Arc::new(reg)

--- a/server/main.rs
+++ b/server/main.rs
@@ -389,12 +389,12 @@ async fn build_server_state(
         "overload protection resolved"
     );
     let shared_registry = new_shared_registry();
+    let routing = Arc::new(ArcSwap::from_pointee(initial_snapshot));
 
-    // Build the plugin registry used by IngressDispatcher (PR ②).
-    // Populated with the four built-in ingress handlers; more plugins will be
-    // added as PRs ③–⑥ land.
+    // Build the plugin registry used by IngressDispatcher (PR ②+③).
+    // Populated with the four built-in ingress handlers and the vhost route
+    // resolver; more plugins (metrics, egress, admission) land in PRs ④–⑥.
     let plugin_registry = {
-        use std::sync::Arc;
         use tunnel_lib::plugin::PluginRegistry;
         let mut reg = PluginRegistry::new();
         reg.register_ingress_handler(Arc::new(plugins::tls::TlsHandler {
@@ -410,6 +410,9 @@ async fn build_server_state(
         reg.register_ingress_handler(Arc::new(plugins::tcp_pass::TcpPassHandler {
             registry: shared_registry.clone(),
         }));
+        reg.set_route_resolver(Arc::new(plugins::vhost::VhostPlugin {
+            routing: routing.clone(),
+        }));
         Arc::new(reg)
     };
 
@@ -417,7 +420,7 @@ async fn build_server_state(
         tcp_params: tunnel_lib::TcpParams::from(&config.server.tcp),
         peek_buf_pool: PeekBufPool::new(proxy_buffer_params.peek_buf_size),
         proxy_buffer_params,
-        routing: Arc::new(ArcSwap::from_pointee(initial_snapshot)),
+        routing,
         registry: shared_registry,
         config: Arc::new(config.clone()),
         auth_store,

--- a/server/plugins/h1/mod.rs
+++ b/server/plugins/h1/mod.rs
@@ -23,7 +23,13 @@ impl IngressProtocolHandler for H1Handler {
         ProtocolKind::Http1
     }
 
-    async fn handle(&self, mut stream: TcpStream, route: Route, ctx: &ServerCtx) -> Result<()> {
+    async fn handle(
+        &self,
+        mut stream: TcpStream,
+        route: Option<Route>,
+        ctx: &ServerCtx,
+    ) -> Result<()> {
+        let route = route.ok_or_else(|| anyhow::anyhow!("H1Handler: missing Route"))?;
         let hint = ctx
             .hint
             .as_ref()
@@ -35,19 +41,11 @@ impl IngressProtocolHandler for H1Handler {
             .ok_or_else(|| anyhow::anyhow!("no Host header in plaintext request"))?;
 
         let initial_data: Vec<u8> = hint.raw_preface.to_vec();
-        let protocol = {
-            use tunnel_lib::proxy::core::Protocol;
-            // WebSocket detection: raw_preface already parsed by dispatcher;
-            // hint.authority presence is enough — use H1 as default, WS if preface
-            // contains Upgrade header (detect_protocol_and_host already handled this).
-            if initial_data
-                .windows(9)
-                .any(|w| w.eq_ignore_ascii_case(b"websocket"))
-            {
-                Protocol::WebSocket
-            } else {
-                Protocol::H1
+        let protocol = match hint.protocol {
+            tunnel_lib::proxy::core::Protocol::WebSocket => {
+                tunnel_lib::proxy::core::Protocol::WebSocket
             }
+            _ => tunnel_lib::proxy::core::Protocol::H1,
         };
 
         debug!(host = %host, protocol = ?protocol, "plaintext H1/WS, byte-level forwarding");
@@ -89,7 +87,7 @@ impl IngressProtocolHandler for H1Handler {
             recv,
             stream,
             &initial_data,
-            tunnel_lib::proxy::ProxyBufferParams::default().relay_buf_size,
+            ctx.relay_buf_size,
         )
         .await
     }

--- a/server/plugins/h1/mod.rs
+++ b/server/plugins/h1/mod.rs
@@ -1,0 +1,96 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use std::time::Duration;
+use tokio::io::AsyncReadExt;
+use tokio::net::TcpStream;
+use tracing::debug;
+
+use tunnel_lib::plugin::{IngressProtocolHandler, ProtocolKind, Route, ServerCtx};
+
+use crate::registry::SharedRegistry;
+
+/// Handles HTTP/1.x and WebSocket connections using byte-level forwarding.
+///
+/// Replays the peeked preface bytes into the QUIC tunnel so the client sees
+/// the full original request.
+pub struct H1Handler {
+    pub registry: SharedRegistry,
+}
+
+#[async_trait]
+impl IngressProtocolHandler for H1Handler {
+    fn protocol_kind(&self) -> ProtocolKind {
+        ProtocolKind::Http1
+    }
+
+    async fn handle(&self, mut stream: TcpStream, route: Route, ctx: &ServerCtx) -> Result<()> {
+        let hint = ctx
+            .hint
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("H1Handler: missing ProtocolHint"))?;
+
+        let host = hint
+            .authority
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("no Host header in plaintext request"))?;
+
+        let initial_data: Vec<u8> = hint.raw_preface.to_vec();
+        let protocol = {
+            use tunnel_lib::proxy::core::Protocol;
+            // WebSocket detection: raw_preface already parsed by dispatcher;
+            // hint.authority presence is enough — use H1 as default, WS if preface
+            // contains Upgrade header (detect_protocol_and_host already handled this).
+            if initial_data
+                .windows(9)
+                .any(|w| w.eq_ignore_ascii_case(b"websocket"))
+            {
+                Protocol::WebSocket
+            } else {
+                Protocol::H1
+            }
+        };
+
+        debug!(host = %host, protocol = ?protocol, "plaintext H1/WS, byte-level forwarding");
+
+        let (group_id, proxy_name) = (route.group_id, route.proxy_name);
+        let selected = self
+            .registry
+            .select_client_for_group(&group_id)
+            .ok_or_else(|| anyhow::anyhow!("no client for group: {}", group_id))?;
+
+        // Consume the peeked bytes from the stream before handing it to relay.
+        let mut discard = vec![0u8; initial_data.len()];
+        stream.read_exact(&mut discard).await?;
+
+        let routing_info = tunnel_lib::RoutingInfo {
+            proxy_name: proxy_name.to_string(),
+            src_addr: ctx.peer_addr.ip().to_string(),
+            src_port: ctx.peer_addr.port(),
+            protocol,
+            host: Some(host),
+        };
+
+        let open_timeout = Duration::from_millis(ctx.timeouts.open_stream_ms);
+        let opened = tunnel_lib::open_bi_guarded(
+            &selected.conn,
+            &selected.inflight,
+            &ctx.overload,
+            open_timeout,
+            |_elapsed, _outcome| {},
+        )
+        .await?;
+
+        let mut send = opened.send;
+        let recv = opened.recv;
+        let _inflight_guard = opened.inflight;
+        tunnel_lib::send_routing_info(&mut send, &routing_info).await?;
+        tunnel_lib::proxy::forward_with_initial_data(
+            send,
+            recv,
+            stream,
+            &initial_data,
+            tunnel_lib::proxy::ProxyBufferParams::default().relay_buf_size,
+        )
+        .await
+    }
+}

--- a/server/plugins/h2c/mod.rs
+++ b/server/plugins/h2c/mod.rs
@@ -102,8 +102,6 @@ impl IngressProtocolHandler for H2cHandler {
                     }
                 }
 
-                // Use initial route for group lookup; per-request vhost → RouteTarget
-                // resolution is intentionally left for PR ③ (RouteResolver plugin).
                 let route_target = {
                     let mut cache = route_cache.lock().unwrap();
                     cache

--- a/server/plugins/h2c/mod.rs
+++ b/server/plugins/h2c/mod.rs
@@ -1,0 +1,198 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use http_body_util::{BodyExt, Full};
+use hyper::server::conn::http2::Builder as H2Builder;
+use hyper::service::service_fn;
+use hyper::{Request, Response};
+use hyper_util::rt::TokioIo;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use tokio::net::TcpStream;
+use tracing::debug;
+
+use tunnel_lib::plugin::{IngressProtocolHandler, ProtocolKind, Route, ServerCtx};
+use tunnel_lib::transport::listener::RouteTarget;
+
+use crate::registry::SharedRegistry;
+
+/// Serves HTTP/2 cleartext (h2c) connections with per-request vhost routing
+/// and authority rewriting via the QUIC tunnel.
+pub struct H2cHandler {
+    pub registry: SharedRegistry,
+    /// When true, all requests on a single H2 connection must share the same
+    /// authority (mirrors `h2_single_authority` config option).
+    pub single_authority: bool,
+}
+
+#[async_trait]
+impl IngressProtocolHandler for H2cHandler {
+    fn protocol_kind(&self) -> ProtocolKind {
+        ProtocolKind::H2c
+    }
+
+    async fn handle(&self, stream: TcpStream, route: Route, ctx: &ServerCtx) -> Result<()> {
+        debug!("plaintext H2 detected, using L7 proxy");
+        let src_addr = ctx.peer_addr.ip().to_string();
+        let src_port = ctx.peer_addr.port();
+        let single_authority = self.single_authority;
+        let (_group_id, _proxy_name) = (route.group_id.clone(), route.proxy_name.clone());
+
+        let first_authority: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        // route_cache: host → Option<RouteTarget> (None = no route found)
+        let route_cache: Arc<Mutex<HashMap<String, Option<RouteTarget>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let sender_cache: Arc<
+            Mutex<HashMap<RouteTarget, (quinn::Connection, tunnel_lib::H2Sender)>>,
+        > = Arc::new(Mutex::new(HashMap::new()));
+
+        let registry = self.registry.clone();
+
+        // The route passed in from the dispatcher is for the initial sniff host.
+        // For H2c each request can target a different authority, so we look up
+        // per-request inside the service closure (mirroring legacy behaviour).
+        let initial_route = RouteTarget {
+            group_id: route.group_id,
+            proxy_name: route.proxy_name,
+        };
+
+        let service = service_fn(move |req: Request<hyper::body::Incoming>| {
+            let registry = registry.clone();
+            let first_authority = first_authority.clone();
+            let route_cache = route_cache.clone();
+            let sender_cache = sender_cache.clone();
+            let initial_route = initial_route.clone();
+            let src_addr = src_addr.clone();
+            async move {
+                let authority = req.uri().authority().map(|a| a.to_string()).or_else(|| {
+                    req.headers()
+                        .get(hyper::header::HOST)
+                        .and_then(|h| h.to_str().ok())
+                        .map(|s| s.to_string())
+                });
+                let host = match authority {
+                    Some(h) => h,
+                    None => {
+                        return Ok(Response::builder()
+                            .status(400)
+                            .body(
+                                Full::new(bytes::Bytes::from("Missing authority"))
+                                    .map_err(|_| unreachable!())
+                                    .boxed(),
+                            )
+                            .unwrap());
+                    }
+                };
+                let route_host = host.split(':').next().unwrap_or(&host).to_ascii_lowercase();
+
+                if single_authority {
+                    let mut fa = first_authority.lock().unwrap();
+                    match fa.as_ref() {
+                        None => *fa = Some(route_host.clone()),
+                        Some(pinned) if pinned != &route_host => {
+                            return Ok(Response::builder()
+                                .status(421)
+                                .body(
+                                    Full::new(bytes::Bytes::from("Misdirected Request"))
+                                        .map_err(|_| unreachable!())
+                                        .boxed(),
+                                )
+                                .unwrap());
+                        }
+                        Some(_) => {}
+                    }
+                }
+
+                // Use initial route for group lookup; per-request vhost → RouteTarget
+                // resolution is intentionally left for PR ③ (RouteResolver plugin).
+                let route_target = {
+                    let mut cache = route_cache.lock().unwrap();
+                    cache
+                        .entry(route_host.clone())
+                        .or_insert_with(|| Some(initial_route.clone()))
+                        .clone()
+                };
+                let route_target = match route_target {
+                    Some(r) => r,
+                    None => {
+                        return Ok(Response::builder()
+                            .status(404)
+                            .body(
+                                Full::new(bytes::Bytes::from("No route"))
+                                    .map_err(|_| unreachable!())
+                                    .boxed(),
+                            )
+                            .unwrap());
+                    }
+                };
+
+                let (conn_group_id, proxy_name) =
+                    (route_target.group_id.clone(), route_target.proxy_name.clone());
+                let (client_conn, h2_sender) = {
+                    let mut guard = sender_cache.lock().unwrap();
+                    if !guard.contains_key(&route_target) {
+                        if let Some(selected) =
+                            registry.select_client_for_group(&conn_group_id)
+                        {
+                            guard.insert(
+                                route_target.clone(),
+                                (selected.conn, tunnel_lib::new_h2_sender()),
+                            );
+                        }
+                    }
+                    match guard.get(&route_target) {
+                        Some(pair) => (pair.0.clone(), pair.1.clone()),
+                        None => {
+                            return Ok(Response::builder()
+                                .status(502)
+                                .body(
+                                    Full::new(bytes::Bytes::from("No client available"))
+                                        .map_err(|_| unreachable!())
+                                        .boxed(),
+                                )
+                                .unwrap());
+                        }
+                    }
+                };
+
+                let (parts, body) = req.into_parts();
+                debug!(
+                    "L7 Proxy (plaintext H2): {} {} -> {}",
+                    parts.method, parts.uri, host
+                );
+                let routing_info = tunnel_lib::RoutingInfo {
+                    proxy_name: proxy_name.to_string(),
+                    src_addr,
+                    src_port,
+                    protocol: tunnel_lib::proxy::core::Protocol::H2,
+                    host: Some(host),
+                };
+                let boxed_body = body.map_err(std::io::Error::other).boxed();
+                let upstream_req = Request::from_parts(parts, boxed_body);
+                match tunnel_lib::forward_h2_request(&client_conn, &h2_sender, routing_info, upstream_req)
+                    .await
+                {
+                    Ok(resp) => Ok::<_, hyper::Error>(resp),
+                    Err(e) => {
+                        tracing::error!("L7 Proxy upstream error: {}", e);
+                        sender_cache.lock().unwrap().remove(&route_target);
+                        Ok(Response::builder()
+                            .status(502)
+                            .body(
+                                Full::new(bytes::Bytes::from("Bad Gateway"))
+                                    .map_err(|_| unreachable!())
+                                    .boxed(),
+                            )
+                            .unwrap())
+                    }
+                }
+            }
+        });
+
+        let io = TokioIo::new(stream);
+        H2Builder::new(hyper_util::rt::TokioExecutor::new())
+            .serve_connection(io, service)
+            .await
+            .map_err(|e| anyhow::anyhow!("H2 connection error: {}", e))?;
+        Ok(())
+    }
+}

--- a/server/plugins/h2c/mod.rs
+++ b/server/plugins/h2c/mod.rs
@@ -10,17 +10,25 @@ use std::sync::{Arc, Mutex};
 use tokio::net::TcpStream;
 use tracing::debug;
 
-use tunnel_lib::plugin::{IngressProtocolHandler, ProtocolKind, Route, ServerCtx};
+use tunnel_lib::plugin::{
+    IngressProtocolHandler, PhaseResult, ProtocolHint, ProtocolKind, Route, RouteCtx,
+    RouteResolver, ServerCtx,
+};
 use tunnel_lib::transport::listener::RouteTarget;
 
 use crate::registry::SharedRegistry;
 
 /// Serves HTTP/2 cleartext (h2c) connections with per-request vhost routing
 /// and authority rewriting via the QUIC tunnel.
+///
+/// Holds its own `RouteResolver` reference because H2 multiplexes many
+/// authorities on one TCP connection. The dispatcher's Phase 4 runs once
+/// per connection; this handler re-resolves per request with the request's
+/// `:authority`. This is why `IngressDispatcher` skips Phase 4 for
+/// `ProtocolKind::H2c` and passes `None` as the route.
 pub struct H2cHandler {
     pub registry: SharedRegistry,
-    /// When true, all requests on a single H2 connection must share the same
-    /// authority (mirrors `h2_single_authority` config option).
+    pub route_resolver: Arc<dyn RouteResolver>,
     pub single_authority: bool,
 }
 
@@ -30,15 +38,20 @@ impl IngressProtocolHandler for H2cHandler {
         ProtocolKind::H2c
     }
 
-    async fn handle(&self, stream: TcpStream, route: Route, ctx: &ServerCtx) -> Result<()> {
+    async fn handle(
+        &self,
+        stream: TcpStream,
+        _route: Option<Route>,
+        ctx: &ServerCtx,
+    ) -> Result<()> {
         debug!("plaintext H2 detected, using L7 proxy");
         let src_addr = ctx.peer_addr.ip().to_string();
         let src_port = ctx.peer_addr.port();
+        let listener_port = ctx.listener_port;
+        let client_addr = ctx.peer_addr;
         let single_authority = self.single_authority;
-        let (_group_id, _proxy_name) = (route.group_id.clone(), route.proxy_name.clone());
 
         let first_authority: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
-        // route_cache: host → Option<RouteTarget> (None = no route found)
         let route_cache: Arc<Mutex<HashMap<String, Option<RouteTarget>>>> =
             Arc::new(Mutex::new(HashMap::new()));
         let sender_cache: Arc<
@@ -46,21 +59,14 @@ impl IngressProtocolHandler for H2cHandler {
         > = Arc::new(Mutex::new(HashMap::new()));
 
         let registry = self.registry.clone();
-
-        // The route passed in from the dispatcher is for the initial sniff host.
-        // For H2c each request can target a different authority, so we look up
-        // per-request inside the service closure (mirroring legacy behaviour).
-        let initial_route = RouteTarget {
-            group_id: route.group_id,
-            proxy_name: route.proxy_name,
-        };
+        let route_resolver = self.route_resolver.clone();
 
         let service = service_fn(move |req: Request<hyper::body::Incoming>| {
             let registry = registry.clone();
             let first_authority = first_authority.clone();
             let route_cache = route_cache.clone();
             let sender_cache = sender_cache.clone();
-            let initial_route = initial_route.clone();
+            let route_resolver = route_resolver.clone();
             let src_addr = src_addr.clone();
             async move {
                 let authority = req.uri().authority().map(|a| a.to_string()).or_else(|| {
@@ -102,12 +108,40 @@ impl IngressProtocolHandler for H2cHandler {
                     }
                 }
 
-                let route_target = {
-                    let mut cache = route_cache.lock().unwrap();
-                    cache
-                        .entry(route_host.clone())
-                        .or_insert_with(|| Some(initial_route.clone()))
-                        .clone()
+                let cached_route = { route_cache.lock().unwrap().get(&route_host).cloned() };
+                let route_target = match cached_route {
+                    Some(route) => route,
+                    None => {
+                        let resolve_ctx = RouteCtx {
+                            listener_port,
+                            client_addr,
+                            hint: ProtocolHint::new(ProtocolKind::H2c, bytes::Bytes::new())
+                                .with_authority(route_host.clone()),
+                        };
+                        let resolved = match route_resolver.resolve(&resolve_ctx).await {
+                            Ok(PhaseResult::Continue(route)) => Some(RouteTarget {
+                                group_id: route.group_id,
+                                proxy_name: route.proxy_name,
+                            }),
+                            Ok(PhaseResult::Reject { .. }) => None,
+                            Err(e) => {
+                                tracing::error!(error = %e, host = %route_host, "h2c route resolve failed");
+                                return Ok(Response::builder()
+                                    .status(502)
+                                    .body(
+                                        Full::new(bytes::Bytes::from("Bad Gateway"))
+                                            .map_err(|_| unreachable!())
+                                            .boxed(),
+                                    )
+                                    .unwrap());
+                            }
+                        };
+                        route_cache
+                            .lock()
+                            .unwrap()
+                            .insert(route_host.clone(), resolved.clone());
+                        resolved
+                    }
                 };
                 let route_target = match route_target {
                     Some(r) => r,

--- a/server/plugins/mod.rs
+++ b/server/plugins/mod.rs
@@ -1,5 +1,6 @@
 pub mod h1;
 pub mod h2c;
+pub mod prometheus;
 pub mod tcp_pass;
 pub mod tls;
 pub mod vhost;

--- a/server/plugins/mod.rs
+++ b/server/plugins/mod.rs
@@ -1,0 +1,4 @@
+pub mod h1;
+pub mod h2c;
+pub mod tcp_pass;
+pub mod tls;

--- a/server/plugins/mod.rs
+++ b/server/plugins/mod.rs
@@ -2,3 +2,4 @@ pub mod h1;
 pub mod h2c;
 pub mod tcp_pass;
 pub mod tls;
+pub mod vhost;

--- a/server/plugins/prometheus/mod.rs
+++ b/server/plugins/prometheus/mod.rs
@@ -1,28 +1,30 @@
+use metrics::{counter, histogram, Label};
+
 use tunnel_lib::plugin::MetricsSink;
 
-/// `MetricsSink` implementation backed by the `metrics` crate, which the
-/// server already uses via `metrics_exporter_prometheus` (see
-/// `server/metrics.rs`).
+/// `MetricsSink` implementation backed by the `metrics` crate.
 ///
-/// Runtime-computed label values are forwarded by cloning the string — this
-/// matches how `server/metrics.rs` already does it for `group_id` / `status`
-/// labels. The metric name is `&'static str`, so no allocation on the name.
+/// Label keys arrive as `&'static str` and pass through `Label::new` without
+/// allocation (the crate's `SharedString` can hold a static borrow via
+/// `const_str`). Values are borrowed `&str` so each runtime-computed value
+/// costs one `String` allocation. The `metrics` crate internally materialises
+/// labels into a `Vec<Label>` no matter what we pass in, so no upstream
+/// zero-alloc path exists for dynamic labels.
 pub struct PrometheusSink;
 
+fn build_labels(labels: &[(&'static str, &str)]) -> Vec<Label> {
+    labels
+        .iter()
+        .map(|(k, v)| Label::new(*k, v.to_string()))
+        .collect()
+}
+
 impl MetricsSink for PrometheusSink {
-    fn incr(&self, name: &'static str, labels: &[(&str, &str)]) {
-        let owned: Vec<(String, String)> = labels
-            .iter()
-            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
-            .collect();
-        metrics::counter!(name, &owned).increment(1);
+    fn incr(&self, name: &'static str, labels: &[(&'static str, &str)]) {
+        counter!(name, build_labels(labels)).increment(1);
     }
 
-    fn observe(&self, name: &'static str, value: f64, labels: &[(&str, &str)]) {
-        let owned: Vec<(String, String)> = labels
-            .iter()
-            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
-            .collect();
-        metrics::histogram!(name, &owned).record(value);
+    fn observe(&self, name: &'static str, value: f64, labels: &[(&'static str, &str)]) {
+        histogram!(name, build_labels(labels)).record(value);
     }
 }

--- a/server/plugins/prometheus/mod.rs
+++ b/server/plugins/prometheus/mod.rs
@@ -1,0 +1,28 @@
+use tunnel_lib::plugin::MetricsSink;
+
+/// `MetricsSink` implementation backed by the `metrics` crate, which the
+/// server already uses via `metrics_exporter_prometheus` (see
+/// `server/metrics.rs`).
+///
+/// Runtime-computed label values are forwarded by cloning the string — this
+/// matches how `server/metrics.rs` already does it for `group_id` / `status`
+/// labels. The metric name is `&'static str`, so no allocation on the name.
+pub struct PrometheusSink;
+
+impl MetricsSink for PrometheusSink {
+    fn incr(&self, name: &'static str, labels: &[(&str, &str)]) {
+        let owned: Vec<(String, String)> = labels
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        metrics::counter!(name, &owned).increment(1);
+    }
+
+    fn observe(&self, name: &'static str, value: f64, labels: &[(&str, &str)]) {
+        let owned: Vec<(String, String)> = labels
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        metrics::histogram!(name, &owned).record(value);
+    }
+}

--- a/server/plugins/tcp_pass/mod.rs
+++ b/server/plugins/tcp_pass/mod.rs
@@ -1,0 +1,73 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use std::time::Duration;
+use tokio::net::TcpStream;
+use tracing::debug;
+
+use tunnel_lib::plugin::{IngressProtocolHandler, ProtocolKind, Route, ServerCtx};
+
+use crate::registry::SharedRegistry;
+
+/// Passthrough TCP handler: forwards raw bytes without protocol inspection.
+///
+/// Used for opaque TLS or any unrecognised protocol (ProtocolKind::Tcp).
+pub struct TcpPassHandler {
+    pub registry: SharedRegistry,
+}
+
+#[async_trait]
+impl IngressProtocolHandler for TcpPassHandler {
+    fn protocol_kind(&self) -> ProtocolKind {
+        ProtocolKind::Tcp
+    }
+
+    async fn handle(&self, stream: TcpStream, route: Route, ctx: &ServerCtx) -> Result<()> {
+        let hint = ctx.hint.as_ref();
+        let host = hint.and_then(|h| h.sni.clone().or_else(|| h.authority.clone()));
+        let initial_data = hint
+            .map(|h| h.raw_preface.to_vec())
+            .unwrap_or_default();
+
+        debug!(
+            host = ?host,
+            initial_len = initial_data.len(),
+            "TCP passthrough"
+        );
+
+        let (group_id, proxy_name) = (route.group_id, route.proxy_name);
+        let selected = self
+            .registry
+            .select_client_for_group(&group_id)
+            .ok_or_else(|| anyhow::anyhow!("no client for group: {}", group_id))?;
+
+        let routing_info = tunnel_lib::RoutingInfo {
+            proxy_name: proxy_name.to_string(),
+            src_addr: ctx.peer_addr.ip().to_string(),
+            src_port: ctx.peer_addr.port(),
+            protocol: tunnel_lib::proxy::core::Protocol::Tcp,
+            host,
+        };
+
+        let open_timeout = Duration::from_millis(ctx.timeouts.open_stream_ms);
+        let opened = tunnel_lib::open_bi_guarded(
+            &selected.conn,
+            &selected.inflight,
+            &ctx.overload,
+            open_timeout,
+            |_elapsed, _outcome| {},
+        )
+        .await?;
+
+        let mut send = opened.send;
+        let recv = opened.recv;
+        let _inflight_guard = opened.inflight;
+        tunnel_lib::send_routing_info(&mut send, &routing_info).await?;
+        tunnel_lib::proxy::forward_to_client(
+            send,
+            recv,
+            stream,
+            tunnel_lib::proxy::ProxyBufferParams::default().relay_buf_size,
+        )
+        .await
+    }
+}

--- a/server/plugins/tcp_pass/mod.rs
+++ b/server/plugins/tcp_pass/mod.rs
@@ -21,7 +21,13 @@ impl IngressProtocolHandler for TcpPassHandler {
         ProtocolKind::Tcp
     }
 
-    async fn handle(&self, stream: TcpStream, route: Route, ctx: &ServerCtx) -> Result<()> {
+    async fn handle(
+        &self,
+        stream: TcpStream,
+        route: Option<Route>,
+        ctx: &ServerCtx,
+    ) -> Result<()> {
+        let route = route.ok_or_else(|| anyhow::anyhow!("TcpPassHandler: missing Route"))?;
         let hint = ctx.hint.as_ref();
         let host = hint.and_then(|h| h.sni.clone().or_else(|| h.authority.clone()));
         let initial_data = hint
@@ -66,7 +72,7 @@ impl IngressProtocolHandler for TcpPassHandler {
             send,
             recv,
             stream,
-            tunnel_lib::proxy::ProxyBufferParams::default().relay_buf_size,
+            ctx.relay_buf_size,
         )
         .await
     }

--- a/server/plugins/tls/mod.rs
+++ b/server/plugins/tls/mod.rs
@@ -24,7 +24,13 @@ impl IngressProtocolHandler for TlsHandler {
         ProtocolKind::Tls
     }
 
-    async fn handle(&self, stream: TcpStream, route: Route, ctx: &ServerCtx) -> Result<()> {
+    async fn handle(
+        &self,
+        stream: TcpStream,
+        route: Option<Route>,
+        ctx: &ServerCtx,
+    ) -> Result<()> {
+        let route = route.ok_or_else(|| anyhow::anyhow!("TlsHandler: missing Route"))?;
         let host = ctx
             .hint
             .as_ref()

--- a/server/plugins/tls/mod.rs
+++ b/server/plugins/tls/mod.rs
@@ -1,0 +1,113 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use http_body_util::{BodyExt, Full};
+use hyper::server::conn::http2::Builder as H2Builder;
+use hyper::service::service_fn;
+use hyper::{Request, Response};
+use hyper_util::rt::TokioIo;
+use tokio::net::TcpStream;
+use tracing::{debug, info};
+
+use tunnel_lib::plugin::{IngressProtocolHandler, ProtocolKind, Route, ServerCtx};
+
+use crate::registry::SharedRegistry;
+
+/// Terminates TLS (self-signed cert via PKI cache), then serves the inner
+/// connection as HTTP/2 with authority rewriting via the QUIC tunnel.
+pub struct TlsHandler {
+    pub registry: SharedRegistry,
+}
+
+#[async_trait]
+impl IngressProtocolHandler for TlsHandler {
+    fn protocol_kind(&self) -> ProtocolKind {
+        ProtocolKind::Tls
+    }
+
+    async fn handle(&self, stream: TcpStream, route: Route, ctx: &ServerCtx) -> Result<()> {
+        let host = ctx
+            .hint
+            .as_ref()
+            .and_then(|h| h.sni.clone())
+            .ok_or_else(|| anyhow::anyhow!("TlsHandler: no SNI in ProtocolHint"))?;
+
+        debug!(host = %host, "TLS connection: terminating");
+        let server_config = tunnel_lib::infra::pki::get_or_create_server_config(&host)?;
+        let acceptor = tokio_rustls::TlsAcceptor::from(server_config);
+        let tls_stream = acceptor.accept(stream).await?;
+        info!("TLS terminated, serving H2 with authority rewriting");
+
+        let (group_id, proxy_name) = (route.group_id.clone(), route.proxy_name.clone());
+        let peer_addr = ctx.peer_addr;
+        let src_addr = peer_addr.ip().to_string();
+        let src_port = peer_addr.port();
+        let target_host = host.clone();
+
+        let selected = self
+            .registry
+            .select_client_for_group(&group_id)
+            .ok_or_else(|| anyhow::anyhow!("no client for group: {}", group_id))?;
+        let client_conn = selected.conn;
+        let sender_cache = tunnel_lib::new_h2_sender();
+
+        let service = service_fn(move |req: Request<hyper::body::Incoming>| {
+            let client_conn = client_conn.clone();
+            let sender_cache = sender_cache.clone();
+            let proxy_name = proxy_name.clone();
+            let target_host = target_host.clone();
+            let src_addr = src_addr.clone();
+            async move {
+                let (mut parts, body) = req.into_parts();
+                let mut uri_parts = parts.uri.clone().into_parts();
+                if let Ok(authority) = target_host.parse() {
+                    uri_parts.authority = Some(authority);
+                }
+                parts.uri = hyper::Uri::from_parts(uri_parts).unwrap_or(parts.uri);
+                if let Ok(host_value) = target_host.parse() {
+                    parts.headers.insert(hyper::header::HOST, host_value);
+                }
+                debug!(
+                    "L7 Proxy: rewriting authority to {}, forwarding {} {}",
+                    target_host, parts.method, parts.uri
+                );
+                let routing_info = tunnel_lib::RoutingInfo {
+                    proxy_name: proxy_name.to_string(),
+                    src_addr,
+                    src_port,
+                    protocol: tunnel_lib::proxy::core::Protocol::H2,
+                    host: Some(target_host),
+                };
+                let boxed_body = body.map_err(std::io::Error::other).boxed();
+                let upstream_req = Request::from_parts(parts, boxed_body);
+                match tunnel_lib::forward_h2_request(
+                    &client_conn,
+                    &sender_cache,
+                    routing_info,
+                    upstream_req,
+                )
+                .await
+                {
+                    Ok(resp) => Ok::<_, hyper::Error>(resp),
+                    Err(e) => {
+                        tracing::error!("L7 Proxy upstream error: {}", e);
+                        Ok(Response::builder()
+                            .status(502)
+                            .body(
+                                Full::new(bytes::Bytes::from("Bad Gateway"))
+                                    .map_err(|_| unreachable!())
+                                    .boxed(),
+                            )
+                            .unwrap())
+                    }
+                }
+            }
+        });
+
+        let io = TokioIo::new(tls_stream);
+        H2Builder::new(hyper_util::rt::TokioExecutor::new())
+            .serve_connection(io, service)
+            .await
+            .map_err(|e| anyhow::anyhow!("H2 connection error: {}", e))?;
+        Ok(())
+    }
+}

--- a/server/plugins/vhost/mod.rs
+++ b/server/plugins/vhost/mod.rs
@@ -1,0 +1,46 @@
+use anyhow::Result;
+use arc_swap::ArcSwap;
+use async_trait::async_trait;
+use std::sync::Arc;
+
+use tunnel_lib::plugin::{PhaseResult, Route, RouteCtx, RouteResolver};
+
+use crate::RoutingSnapshot;
+
+/// Route resolver that looks up the vhost router from the current
+/// `RoutingSnapshot` (exact + wildcard match).
+///
+/// Internally uses `VhostRouter<RouteTarget>` which is already populated by
+/// `build_routing_snapshot` — no duplicate data structures.
+pub struct VhostPlugin {
+    pub routing: Arc<ArcSwap<RoutingSnapshot>>,
+}
+
+#[async_trait]
+impl RouteResolver for VhostPlugin {
+    async fn resolve(&self, ctx: &RouteCtx) -> Result<PhaseResult<Route>> {
+        let host = ctx
+            .hint
+            .sni
+            .clone()
+            .or_else(|| ctx.hint.authority.clone())
+            .unwrap_or_default();
+
+        let snapshot = self.routing.load();
+        let target = snapshot
+            .http_routers
+            .get(&ctx.listener_port)
+            .and_then(|router| router.get(&host));
+
+        match target {
+            Some(t) => Ok(PhaseResult::Continue(Route::new(
+                t.group_id.as_ref(),
+                t.proxy_name.as_ref(),
+            ))),
+            None => Ok(PhaseResult::Reject {
+                status: 404,
+                message: format!("no vhost route for host '{}' on port {}", host, ctx.listener_port).into(),
+            }),
+        }
+    }
+}

--- a/server/tunnel_service.rs
+++ b/server/tunnel_service.rs
@@ -1,60 +1,16 @@
 use anyhow::Result;
-use arc_swap::ArcSwap;
 use async_trait::async_trait;
-use std::sync::Arc;
 
-use tunnel_lib::plugin::{
-    AdmissionReq, PhaseOutcome, PhaseResult, Route, RouteCtx, TunnelService,
-};
-
-use crate::RoutingSnapshot;
-
-// Re-export so handlers can use it without a full path.
-pub use pported::PortedTunnelService;
-
-mod pported {
-    use super::*;
-
-    /// Wraps `DefaultTunnelService` to inject a known listener `port` into
-    /// `RouteCtx` so vhost lookup works correctly even when `peer_addr.port()`
-    /// is the ephemeral client port, not the listener port.
-    pub struct PortedTunnelService {
-        pub inner: DefaultTunnelService,
-        pub port: u16,
-    }
-
-    #[async_trait]
-    impl TunnelService for PortedTunnelService {
-        async fn admission(&self, req: &AdmissionReq) -> Result<PhaseResult> {
-            self.inner.admission(req).await
-        }
-
-        async fn resolve_route(&self, ctx: &RouteCtx) -> Result<PhaseResult<Route>> {
-            // Rebuild ctx with the correct listener port.
-            let patched = RouteCtx {
-                listener_port: self.port,
-                ..ctx.clone()
-            };
-            self.inner.resolve_route(&patched).await
-        }
-
-        fn logging(&self, outcome: &PhaseOutcome) {
-            self.inner.logging(outcome);
-        }
-    }
-}
+use tunnel_lib::plugin::{AdmissionReq, PhaseOutcome, PhaseResult, TunnelService};
 
 /// Default server-side implementation of `TunnelService`.
 ///
-/// Phase 2 (admission): always allows for now — token validation is done
-/// upstream in the QUIC login flow.  Will be replaced by `admission-token`
-/// plugin in PR ③.
+/// Admission currently always allows — QUIC login performs token validation
+/// upstream. Logging is a placeholder until PR ④ wires `MetricsSink` in.
 ///
-/// Phase 3 (route resolve): looks up the vhost router from the current
-/// `RoutingSnapshot`.
-pub struct DefaultTunnelService {
-    pub routing: Arc<ArcSwap<RoutingSnapshot>>,
-}
+/// Route resolution lives in `RouteResolver` (see `server/plugins/vhost/`),
+/// injected into the registry at startup.
+pub struct DefaultTunnelService;
 
 #[async_trait]
 impl TunnelService for DefaultTunnelService {
@@ -62,33 +18,5 @@ impl TunnelService for DefaultTunnelService {
         Ok(PhaseResult::Continue(()))
     }
 
-    async fn resolve_route(&self, ctx: &RouteCtx) -> Result<PhaseResult<Route>> {
-        let host = ctx
-            .hint
-            .sni
-            .clone()
-            .or_else(|| ctx.hint.authority.clone())
-            .unwrap_or_default();
-
-        let snapshot = self.routing.load();
-        let target = snapshot
-            .http_routers
-            .get(&ctx.listener_port)
-            .and_then(|router| router.get(&host));
-
-        match target {
-            Some(t) => Ok(PhaseResult::Continue(Route::new(
-                t.group_id.as_ref(),
-                t.proxy_name.as_ref(),
-            ))),
-            None => Ok(PhaseResult::Reject {
-                status: 404,
-                message: format!("no route for host: {}", host).into(),
-            }),
-        }
-    }
-
-    fn logging(&self, _outcome: &PhaseOutcome) {
-        // Metrics will be hooked here in PR ④.
-    }
+    fn logging(&self, _outcome: &PhaseOutcome) {}
 }

--- a/server/tunnel_service.rs
+++ b/server/tunnel_service.rs
@@ -1,0 +1,94 @@
+use anyhow::Result;
+use arc_swap::ArcSwap;
+use async_trait::async_trait;
+use std::sync::Arc;
+
+use tunnel_lib::plugin::{
+    AdmissionReq, PhaseOutcome, PhaseResult, Route, RouteCtx, TunnelService,
+};
+
+use crate::RoutingSnapshot;
+
+// Re-export so handlers can use it without a full path.
+pub use pported::PortedTunnelService;
+
+mod pported {
+    use super::*;
+
+    /// Wraps `DefaultTunnelService` to inject a known listener `port` into
+    /// `RouteCtx` so vhost lookup works correctly even when `peer_addr.port()`
+    /// is the ephemeral client port, not the listener port.
+    pub struct PortedTunnelService {
+        pub inner: DefaultTunnelService,
+        pub port: u16,
+    }
+
+    #[async_trait]
+    impl TunnelService for PortedTunnelService {
+        async fn admission(&self, req: &AdmissionReq) -> Result<PhaseResult> {
+            self.inner.admission(req).await
+        }
+
+        async fn resolve_route(&self, ctx: &RouteCtx) -> Result<PhaseResult<Route>> {
+            // Rebuild ctx with the correct listener port.
+            let patched = RouteCtx {
+                listener_port: self.port,
+                ..ctx.clone()
+            };
+            self.inner.resolve_route(&patched).await
+        }
+
+        fn logging(&self, outcome: &PhaseOutcome) {
+            self.inner.logging(outcome);
+        }
+    }
+}
+
+/// Default server-side implementation of `TunnelService`.
+///
+/// Phase 2 (admission): always allows for now — token validation is done
+/// upstream in the QUIC login flow.  Will be replaced by `admission-token`
+/// plugin in PR ③.
+///
+/// Phase 3 (route resolve): looks up the vhost router from the current
+/// `RoutingSnapshot`.
+pub struct DefaultTunnelService {
+    pub routing: Arc<ArcSwap<RoutingSnapshot>>,
+}
+
+#[async_trait]
+impl TunnelService for DefaultTunnelService {
+    async fn admission(&self, _req: &AdmissionReq) -> Result<PhaseResult> {
+        Ok(PhaseResult::Continue(()))
+    }
+
+    async fn resolve_route(&self, ctx: &RouteCtx) -> Result<PhaseResult<Route>> {
+        let host = ctx
+            .hint
+            .sni
+            .clone()
+            .or_else(|| ctx.hint.authority.clone())
+            .unwrap_or_default();
+
+        let snapshot = self.routing.load();
+        let target = snapshot
+            .http_routers
+            .get(&ctx.listener_port)
+            .and_then(|router| router.get(&host));
+
+        match target {
+            Some(t) => Ok(PhaseResult::Continue(Route::new(
+                t.group_id.as_ref(),
+                t.proxy_name.as_ref(),
+            ))),
+            None => Ok(PhaseResult::Reject {
+                status: 404,
+                message: format!("no route for host: {}", host).into(),
+            }),
+        }
+    }
+
+    fn logging(&self, _outcome: &PhaseOutcome) {
+        // Metrics will be hooked here in PR ④.
+    }
+}

--- a/server/tunnel_service.rs
+++ b/server/tunnel_service.rs
@@ -1,16 +1,20 @@
 use anyhow::Result;
 use async_trait::async_trait;
+use std::sync::Arc;
 
-use tunnel_lib::plugin::{AdmissionReq, PhaseOutcome, PhaseResult, TunnelService};
+use tunnel_lib::plugin::{AdmissionReq, MetricsSink, PhaseOutcome, PhaseResult, TunnelService};
 
 /// Default server-side implementation of `TunnelService`.
 ///
 /// Admission currently always allows — QUIC login performs token validation
-/// upstream. Logging is a placeholder until PR ④ wires `MetricsSink` in.
+/// upstream. Logging forwards phase timings and error counts into the injected
+/// `MetricsSink`.
 ///
 /// Route resolution lives in `RouteResolver` (see `server/plugins/vhost/`),
 /// injected into the registry at startup.
-pub struct DefaultTunnelService;
+pub struct DefaultTunnelService {
+    pub metrics: Arc<dyn MetricsSink>,
+}
 
 #[async_trait]
 impl TunnelService for DefaultTunnelService {
@@ -18,5 +22,17 @@ impl TunnelService for DefaultTunnelService {
         Ok(PhaseResult::Continue(()))
     }
 
-    fn logging(&self, _outcome: &PhaseOutcome) {}
+    fn logging(&self, outcome: &PhaseOutcome) {
+        let status = if outcome.error.is_some() { "error" } else { "success" };
+        self.metrics
+            .incr("duotunnel_ingress_requests_total", &[("status", status)]);
+
+        if let Some(total) = outcome.timing.total() {
+            self.metrics.observe(
+                "duotunnel_ingress_total_ms",
+                total.as_secs_f64() * 1000.0,
+                &[("status", status)],
+            );
+        }
+    }
 }

--- a/server/tunnel_service.rs
+++ b/server/tunnel_service.rs
@@ -1,20 +1,17 @@
 use anyhow::Result;
 use async_trait::async_trait;
-use std::sync::Arc;
 
-use tunnel_lib::plugin::{AdmissionReq, MetricsSink, PhaseOutcome, PhaseResult, TunnelService};
+use tunnel_lib::plugin::{AdmissionReq, PhaseOutcome, PhaseResult, ServerCtx, TunnelService};
 
 /// Default server-side implementation of `TunnelService`.
 ///
 /// Admission currently always allows — QUIC login performs token validation
-/// upstream. Logging forwards phase timings and error counts into the injected
-/// `MetricsSink`.
+/// upstream. Logging forwards phase timing and success/error counts through
+/// the `MetricsSink` held by `ServerCtx`, so the service itself is stateless.
 ///
 /// Route resolution lives in `RouteResolver` (see `server/plugins/vhost/`),
 /// injected into the registry at startup.
-pub struct DefaultTunnelService {
-    pub metrics: Arc<dyn MetricsSink>,
-}
+pub struct DefaultTunnelService;
 
 #[async_trait]
 impl TunnelService for DefaultTunnelService {
@@ -22,13 +19,14 @@ impl TunnelService for DefaultTunnelService {
         Ok(PhaseResult::Continue(()))
     }
 
-    fn logging(&self, outcome: &PhaseOutcome) {
-        let status = if outcome.error.is_some() { "error" } else { "success" };
-        self.metrics
-            .incr("duotunnel_ingress_requests_total", &[("status", status)]);
-
+    fn logging(&self, ctx: &ServerCtx, outcome: &PhaseOutcome) {
+        // Per-connection timing. The request-completed counter lives on
+        // `server/metrics.rs::request_completed` (named
+        // `duotunnel_requests_total`) to preserve existing dashboards;
+        // don't duplicate it here.
         if let Some(total) = outcome.timing.total() {
-            self.metrics.observe(
+            let status = if outcome.error.is_some() { "error" } else { "success" };
+            ctx.metrics.observe(
                 "duotunnel_ingress_total_ms",
                 total.as_secs_f64() * 1000.0,
                 &[("status", status)],

--- a/tunnel-lib/src/plugin/ctx.rs
+++ b/tunnel-lib/src/plugin/ctx.rs
@@ -162,6 +162,8 @@ pub struct ServerCtx {
     pub overload: OverloadLimits,
     pub timeouts: Timeouts,
     pub peer_addr: SocketAddr,
+    pub listener_port: u16,
+    pub relay_buf_size: usize,
 
     // Timing for the logging phase
     pub timing: PhaseTiming,
@@ -174,6 +176,8 @@ impl ServerCtx {
         tcp_params: Arc<TcpParams>,
         overload: OverloadLimits,
         timeouts: Timeouts,
+        listener_port: u16,
+        relay_buf_size: usize,
     ) -> Self {
         Self {
             metrics,
@@ -184,6 +188,8 @@ impl ServerCtx {
             overload,
             timeouts,
             peer_addr,
+            listener_port,
+            relay_buf_size,
             timing: PhaseTiming::new(),
         }
     }

--- a/tunnel-lib/src/plugin/ctx.rs
+++ b/tunnel-lib/src/plugin/ctx.rs
@@ -134,8 +134,11 @@ pub struct AdmissionReq {
 /// Input to the route-resolve phase (Phase 3).
 #[derive(Debug, Clone)]
 pub struct RouteCtx {
+    /// Port the server accepted this connection on (the listener's local port,
+    /// not the ephemeral remote port).
     pub listener_port: u16,
-    pub peer_addr: SocketAddr,
+    /// Remote peer that opened the connection.
+    pub client_addr: SocketAddr,
     pub hint: ProtocolHint,
 }
 

--- a/tunnel-lib/src/plugin/dispatcher.rs
+++ b/tunnel-lib/src/plugin/dispatcher.rs
@@ -51,7 +51,7 @@ async fn sniff(stream: &TcpStream) -> Result<ProtocolHint> {
     };
 
     let raw_preface = bytes::Bytes::copy_from_slice(data);
-    let mut hint = ProtocolHint::new(kind, raw_preface);
+    let mut hint = ProtocolHint::new(kind, raw_preface).with_protocol(legacy_proto);
 
     match kind {
         ProtocolKind::Tls => {
@@ -155,40 +155,45 @@ impl IngressDispatcher {
         }
 
         // ── Phase 4: RouteResolver::resolve (from registry) ───────────────────
-        let route_ctx = RouteCtx {
-            listener_port: self.listener_port,
-            client_addr: ctx.peer_addr,
-            hint: hint.clone(),
-        };
-        let route = match self.registry.route_resolver.resolve(&route_ctx).await? {
-            PhaseResult::Continue(r) => {
-                timing.route_done_at = Some(Instant::now());
-                r
-            }
-            PhaseResult::Reject { status, message } => {
-                let outcome = PhaseOutcome {
-                    timing,
-                    bytes_sent: 0,
-                    bytes_recv: 0,
-                    error: Some(format!(
-                        "route rejected: status={} msg={}",
-                        status,
-                        String::from_utf8_lossy(&message)
-                    )),
-                };
-                safe_logging(svc, ctx, &outcome);
-                return Err(anyhow!("no route found (status={})", status));
-            }
-        };
-        ctx.route = Some(route.clone());
-
-        // ── Phase 5: IngressProtocolHandler::handle ───────────────────────────
         let handler = self
             .registry
             .ingress_handlers
             .get(&hint.kind)
             .ok_or_else(|| anyhow!("no ingress handler registered for {:?}", hint.kind))?;
 
+        let route = if hint.kind == ProtocolKind::H2c {
+            timing.route_done_at = Some(Instant::now());
+            None
+        } else {
+            let route_ctx = RouteCtx {
+                listener_port: self.listener_port,
+                client_addr: ctx.peer_addr,
+                hint: hint.clone(),
+            };
+            match self.registry.route_resolver.resolve(&route_ctx).await? {
+                PhaseResult::Continue(r) => {
+                    timing.route_done_at = Some(Instant::now());
+                    Some(r)
+                }
+                PhaseResult::Reject { status, message } => {
+                    let outcome = PhaseOutcome {
+                        timing,
+                        bytes_sent: 0,
+                        bytes_recv: 0,
+                        error: Some(format!(
+                            "route rejected: status={} msg={}",
+                            status,
+                            String::from_utf8_lossy(&message)
+                        )),
+                    };
+                    safe_logging(svc, ctx, &outcome);
+                    return Err(anyhow!("no route found (status={})", status));
+                }
+            }
+        };
+        ctx.route = route.clone();
+
+        // ── Phase 5: IngressProtocolHandler::handle ───────────────────────────
         timing.tunnel_open_at = Some(Instant::now());
         ctx.timing = timing.clone();
 

--- a/tunnel-lib/src/plugin/dispatcher.rs
+++ b/tunnel-lib/src/plugin/dispatcher.rs
@@ -1,7 +1,9 @@
 use anyhow::{anyhow, Result};
+use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::net::TcpStream;
+use tracing::error;
 
 use super::ctx::{AdmissionReq, PhaseOutcome, PhaseTiming, PhaseResult, RouteCtx, ServerCtx};
 use super::ingress::{ProtocolHint, ProtocolKind};
@@ -9,6 +11,16 @@ use super::registry::PluginRegistry;
 use super::service::TunnelService;
 use crate::protocol::detect::{detect_protocol_and_host, extract_tls_sni};
 use crate::proxy::core::Protocol;
+
+/// Call `svc.logging` inside `catch_unwind` so a broken implementation can't
+/// tear down the accept worker. Emission errors are dropped — this is the
+/// logging path, nothing above it can recover from a panic here.
+fn safe_logging(svc: &dyn TunnelService, ctx: &ServerCtx, outcome: &PhaseOutcome) {
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| svc.logging(ctx, outcome)));
+    if result.is_err() {
+        error!("TunnelService::logging panicked — metrics/logs dropped for this connection");
+    }
+}
 
 const SNIFF_LIMIT: usize = 256;
 
@@ -112,7 +124,7 @@ impl IngressDispatcher {
                             String::from_utf8_lossy(&message)
                         )),
                     };
-                    svc.logging(&outcome);
+                    safe_logging(svc, ctx, &outcome);
                     return Err(anyhow!("connection rejected at pre_admission (status={})", status));
                 }
                 PhaseResult::Continue(()) => {}
@@ -133,7 +145,7 @@ impl IngressDispatcher {
                         String::from_utf8_lossy(&message)
                     )),
                 };
-                svc.logging(&outcome);
+                safe_logging(svc, ctx, &outcome);
                 return Err(anyhow!("connection rejected at admission (status={})", status));
             }
             PhaseResult::Continue(()) => {
@@ -145,7 +157,7 @@ impl IngressDispatcher {
         // ── Phase 4: RouteResolver::resolve (from registry) ───────────────────
         let route_ctx = RouteCtx {
             listener_port: self.listener_port,
-            peer_addr: ctx.peer_addr,
+            client_addr: ctx.peer_addr,
             hint: hint.clone(),
         };
         let route = match self.registry.route_resolver.resolve(&route_ctx).await? {
@@ -164,7 +176,7 @@ impl IngressDispatcher {
                         String::from_utf8_lossy(&message)
                     )),
                 };
-                svc.logging(&outcome);
+                safe_logging(svc, ctx, &outcome);
                 return Err(anyhow!("no route found (status={})", status));
             }
         };
@@ -190,7 +202,7 @@ impl IngressDispatcher {
             bytes_recv: 0,
             error: handle_result.as_ref().err().map(|e| e.to_string()),
         };
-        svc.logging(&outcome);
+        safe_logging(svc, ctx, &outcome);
 
         handle_result
     }

--- a/tunnel-lib/src/plugin/dispatcher.rs
+++ b/tunnel-lib/src/plugin/dispatcher.rs
@@ -63,19 +63,20 @@ async fn sniff(stream: &TcpStream) -> Result<ProtocolHint> {
 /// Runs the 5-phase ingress pipeline for every accepted TCP connection.
 ///
 /// Phase ordering:
-///   1. `sniff`                   — peek bytes, produce `ProtocolHint` (CORE)
+///   1. `sniff`                          — peek bytes, produce `ProtocolHint` (CORE)
 ///   2. `ConnectionModule::pre_admission` — IP/rate-limit modules, in order
 ///   3. `TunnelService::admission`        — token / auth check
-///   4. `TunnelService::resolve_route`    — vhost / static route lookup
+///   4. `RouteResolver::resolve`          — vhost / static route lookup (from registry)
 ///   5. `IngressProtocolHandler::handle`  — TLS / H2c / H1 / TCP handler
 ///   6. `TunnelService::logging`          — metrics & access logs
 pub struct IngressDispatcher {
     registry: Arc<PluginRegistry>,
+    listener_port: u16,
 }
 
 impl IngressDispatcher {
-    pub fn new(registry: Arc<PluginRegistry>) -> Self {
-        Self { registry }
+    pub fn new(registry: Arc<PluginRegistry>, listener_port: u16) -> Self {
+        Self { registry, listener_port }
     }
 
     pub async fn dispatch(
@@ -141,13 +142,13 @@ impl IngressDispatcher {
             }
         }
 
-        // ── Phase 4: TunnelService::resolve_route ─────────────────────────────
+        // ── Phase 4: RouteResolver::resolve (from registry) ───────────────────
         let route_ctx = RouteCtx {
-            listener_port: ctx.peer_addr.port(), // caller should set this properly
+            listener_port: self.listener_port,
             peer_addr: ctx.peer_addr,
             hint: hint.clone(),
         };
-        let route = match svc.resolve_route(&route_ctx).await? {
+        let route = match self.registry.route_resolver.resolve(&route_ctx).await? {
             PhaseResult::Continue(r) => {
                 timing.route_done_at = Some(Instant::now());
                 r

--- a/tunnel-lib/src/plugin/egress.rs
+++ b/tunnel-lib/src/plugin/egress.rs
@@ -7,12 +7,13 @@ use crate::proxy::tcp::UpstreamScheme;
 
 // ── LoadBalancer ──────────────────────────────────────────────────────────────
 
-/// Select one target from a candidate list.
+/// Select one target from a candidate list, returning its index.
 ///
-/// Sync (no async) because selection algorithms are CPU-bound and must be
-/// fast enough to call on every stream.
+/// Returning an index (rather than a reference) lets callers keep any
+/// parallel data structures in sync without a fragile `ptr::eq` lookup.
+/// Sync because selection algorithms are CPU-bound and called on every stream.
 pub trait LoadBalancer: Send + Sync + 'static {
-    fn pick<'a>(&self, targets: &'a [Target], ctx: &PickCtx) -> Option<&'a Target>;
+    fn pick(&self, targets: &[Target], ctx: &PickCtx) -> Option<usize>;
 }
 
 // ── Connected ─────────────────────────────────────────────────────────────────
@@ -30,8 +31,12 @@ pub struct Connected {
 
 /// Open a connection to a single upstream target.
 ///
-/// Dialers declare which schemes they handle via `matches_scheme`; the
-/// framework picks the first matching dialer in registration order.
+/// Currently unused — the existing `UpstreamResolver` + `PeerKind` pipeline
+/// in `proxy/core.rs` + `proxy/peers.rs` already covers this seam. Kept here
+/// for symmetry with `LoadBalancer` / `Resolver` and to reserve the name, but
+/// not part of any live dispatch path. Do not implement against this trait
+/// without first wiring it through `tunnel-lib/src/proxy/core.rs`.
+#[doc(hidden)]
 #[async_trait]
 pub trait UpstreamDialer: Send + Sync + 'static {
     /// Return true if this dialer can handle the given scheme.

--- a/tunnel-lib/src/plugin/ingress.rs
+++ b/tunnel-lib/src/plugin/ingress.rs
@@ -3,6 +3,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use tokio::net::TcpStream;
 
+use crate::proxy::core::Protocol;
 use super::ctx::{Route, ServerCtx};
 
 // ── ProtocolKind ─────────────────────────────────────────────────────────────
@@ -23,9 +24,16 @@ pub enum ProtocolKind {
 
 /// Full output of Phase 1: protocol kind plus any metadata extractable from
 /// the peek buffer without consuming the stream.
+///
+/// `kind` and `protocol` coexist because they serve different purposes:
+/// `kind` is the handler-dispatch key (four values, stable), while `protocol`
+/// is the wire-level enum forwarded to the upstream via `RoutingInfo`. WS
+/// shares `ProtocolKind::Http1` with H1 but needs `Protocol::WebSocket`
+/// downstream, so the sniffer overrides `protocol` while keeping `kind`.
 #[derive(Debug, Clone)]
 pub struct ProtocolHint {
     pub kind: ProtocolKind,
+    pub protocol: Protocol,
     /// SNI hostname from a TLS ClientHello, if present.
     pub sni: Option<String>,
     /// HTTP `Host` header / H2 `:authority`, if present.
@@ -37,12 +45,23 @@ pub struct ProtocolHint {
 
 impl ProtocolHint {
     pub fn new(kind: ProtocolKind, raw_preface: impl Into<Bytes>) -> Self {
+        let protocol = match kind {
+            ProtocolKind::Tls | ProtocolKind::Tcp => Protocol::Tcp,
+            ProtocolKind::H2c => Protocol::H2,
+            ProtocolKind::Http1 => Protocol::H1,
+        };
         Self {
             kind,
+            protocol,
             sni: None,
             authority: None,
             raw_preface: raw_preface.into(),
         }
+    }
+
+    pub fn with_protocol(mut self, protocol: Protocol) -> Self {
+        self.protocol = protocol;
+        self
     }
 
     pub fn with_sni(mut self, sni: impl Into<String>) -> Self {
@@ -70,13 +89,16 @@ pub trait IngressProtocolHandler: Send + Sync + 'static {
 
     /// Handle an accepted TCP connection.
     ///
-    /// `route` has already been resolved by Phase 3.
+    /// `route` is `Some` when Phase 4 resolved a route per-connection.
+    /// It is `None` for handlers that do their own per-request route lookup
+    /// (currently only `H2cHandler`, which multiplexes many authorities on a
+    /// single connection).
     /// `ctx.hint.raw_preface` contains the bytes that were peeked; the handler
     /// is responsible for prepending them when forwarding to the upstream.
     async fn handle(
         &self,
         stream: TcpStream,
-        route: Route,
+        route: Option<Route>,
         ctx: &ServerCtx,
     ) -> Result<()>;
 }

--- a/tunnel-lib/src/plugin/metrics.rs
+++ b/tunnel-lib/src/plugin/metrics.rs
@@ -2,9 +2,13 @@
 ///
 /// Injected into `ServerCtx` and `EgressCtx`; handlers call `ctx.metrics.incr()`
 /// instead of importing concrete Prometheus symbols.
+///
+/// Label keys are `&'static str` so backends can use a zero-allocation static
+/// registration path (e.g. `metrics::Label::from_static_parts`). Values stay
+/// borrowed `&str` because they're often runtime-computed.
 pub trait MetricsSink: Send + Sync + 'static {
-    fn incr(&self, name: &'static str, labels: &[(&str, &str)]);
-    fn observe(&self, name: &'static str, value: f64, labels: &[(&str, &str)]);
+    fn incr(&self, name: &'static str, labels: &[(&'static str, &str)]);
+    fn observe(&self, name: &'static str, value: f64, labels: &[(&'static str, &str)]);
 }
 
 /// No-op implementation used when metrics are disabled or in tests.
@@ -12,7 +16,7 @@ pub struct NoopSink;
 
 impl MetricsSink for NoopSink {
     #[inline]
-    fn incr(&self, _name: &'static str, _labels: &[(&str, &str)]) {}
+    fn incr(&self, _name: &'static str, _labels: &[(&'static str, &str)]) {}
     #[inline]
-    fn observe(&self, _name: &'static str, _value: f64, _labels: &[(&str, &str)]) {}
+    fn observe(&self, _name: &'static str, _value: f64, _labels: &[(&'static str, &str)]) {}
 }

--- a/tunnel-lib/src/plugin/mod.rs
+++ b/tunnel-lib/src/plugin/mod.rs
@@ -58,7 +58,7 @@ mod tests {
             Ok(PhaseResult::Continue(()))
         }
 
-        fn logging(&self, _outcome: &PhaseOutcome) {}
+        fn logging(&self, _ctx: &ServerCtx, _outcome: &PhaseOutcome) {}
     }
 
     // ── Tests ────────────────────────────────────────────────────────────────
@@ -124,13 +124,41 @@ mod tests {
         assert!(result.is_continue());
     }
 
+    #[test]
+    fn validate_for_ingress_rejects_empty_registry() {
+        let reg = PluginRegistry::new();
+        let err = reg.validate_for_ingress().unwrap_err().to_string();
+        assert!(err.contains("no ingress handlers"), "actual: {err}");
+    }
+
+    #[test]
+    fn validate_for_ingress_rejects_missing_route_resolver() {
+        let mut reg = PluginRegistry::new();
+
+        struct DummyHandler;
+        #[async_trait]
+        impl IngressProtocolHandler for DummyHandler {
+            fn protocol_kind(&self) -> ProtocolKind { ProtocolKind::Tcp }
+            async fn handle(
+                &self,
+                _stream: tokio::net::TcpStream,
+                _route: Route,
+                _ctx: &ServerCtx,
+            ) -> Result<()> { Ok(()) }
+        }
+        reg.register_ingress_handler(Arc::new(DummyHandler));
+
+        let err = reg.validate_for_ingress().unwrap_err().to_string();
+        assert!(err.contains("no route resolver"), "actual: {err}");
+    }
+
     #[tokio::test]
     async fn no_route_resolver_rejects_with_404() {
         let resolver = NoRouteResolver;
         let hint = ProtocolHint::new(ProtocolKind::Http1, bytes::Bytes::new());
         let ctx = RouteCtx {
             listener_port: 8080,
-            peer_addr: "127.0.0.1:1234".parse().unwrap(),
+            client_addr: "127.0.0.1:1234".parse().unwrap(),
             hint,
         };
         let result = resolver.resolve(&ctx).await.unwrap();

--- a/tunnel-lib/src/plugin/mod.rs
+++ b/tunnel-lib/src/plugin/mod.rs
@@ -24,6 +24,7 @@ pub mod ingress;
 pub mod metrics;
 pub mod module;
 pub mod registry;
+pub mod route;
 pub mod service;
 
 // Convenience re-exports for the most commonly used types.
@@ -37,6 +38,7 @@ pub use ingress::{IngressProtocolHandler, ProtocolHint, ProtocolKind};
 pub use metrics::{MetricsSink, NoopSink};
 pub use module::ConnectionModule;
 pub use registry::PluginRegistry;
+pub use route::{NoRouteResolver, RouteResolver};
 pub use service::TunnelService;
 
 #[cfg(test)]
@@ -54,10 +56,6 @@ mod tests {
     impl TunnelService for AlwaysAllowService {
         async fn admission(&self, _req: &AdmissionReq) -> Result<PhaseResult> {
             Ok(PhaseResult::Continue(()))
-        }
-
-        async fn resolve_route(&self, _ctx: &RouteCtx) -> Result<PhaseResult<Route>> {
-            Ok(PhaseResult::Continue(Route::new("test-group", "test-proxy")))
         }
 
         fn logging(&self, _outcome: &PhaseOutcome) {}
@@ -127,21 +125,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn always_allow_service_resolves_route() {
-        let svc = AlwaysAllowService;
+    async fn no_route_resolver_rejects_with_404() {
+        let resolver = NoRouteResolver;
         let hint = ProtocolHint::new(ProtocolKind::Http1, bytes::Bytes::new());
         let ctx = RouteCtx {
             listener_port: 8080,
             peer_addr: "127.0.0.1:1234".parse().unwrap(),
             hint,
         };
-        let result = svc.resolve_route(&ctx).await.unwrap();
+        let result = resolver.resolve(&ctx).await.unwrap();
         match result {
-            PhaseResult::Continue(route) => {
-                assert_eq!(&*route.group_id, "test-group");
-                assert_eq!(&*route.proxy_name, "test-proxy");
-            }
-            _ => panic!("expected Continue"),
+            PhaseResult::Reject { status, .. } => assert_eq!(status, 404),
+            _ => panic!("expected Reject"),
         }
     }
 }

--- a/tunnel-lib/src/plugin/mod.rs
+++ b/tunnel-lib/src/plugin/mod.rs
@@ -142,7 +142,7 @@ mod tests {
             async fn handle(
                 &self,
                 _stream: tokio::net::TcpStream,
-                _route: Route,
+                _route: Option<Route>,
                 _ctx: &ServerCtx,
             ) -> Result<()> { Ok(()) }
         }

--- a/tunnel-lib/src/plugin/registry.rs
+++ b/tunnel-lib/src/plugin/registry.rs
@@ -5,6 +5,7 @@ use super::egress::{LoadBalancer, Resolver, SystemResolver, UpstreamDialer};
 use super::ingress::{IngressProtocolHandler, ProtocolKind};
 use super::metrics::{MetricsSink, NoopSink};
 use super::module::ConnectionModule;
+use super::route::{NoRouteResolver, RouteResolver};
 
 /// Central registry of all runtime plugin instances.
 ///
@@ -23,6 +24,9 @@ pub struct PluginRegistry {
     /// Active metrics backend.  Defaults to `NoopSink`.
     pub metrics_sink: Arc<dyn MetricsSink>,
 
+    /// Active route resolver.  Defaults to `NoRouteResolver` (fail-fast).
+    pub route_resolver: Arc<dyn RouteResolver>,
+
     /// Egress dialers tried in registration order until `matches_scheme` returns true.
     pub dialers: Vec<Arc<dyn UpstreamDialer>>,
 
@@ -40,6 +44,7 @@ impl PluginRegistry {
             ingress_handlers: HashMap::new(),
             modules: Vec::new(),
             metrics_sink: Arc::new(NoopSink),
+            route_resolver: Arc::new(NoRouteResolver),
             dialers: Vec::new(),
             lb: None,
             resolver: Arc::new(SystemResolver),
@@ -59,6 +64,10 @@ impl PluginRegistry {
 
     pub fn set_metrics_sink(&mut self, sink: Arc<dyn MetricsSink>) {
         self.metrics_sink = sink;
+    }
+
+    pub fn set_route_resolver(&mut self, resolver: Arc<dyn RouteResolver>) {
+        self.route_resolver = resolver;
     }
 
     pub fn add_dialer(&mut self, dialer: Arc<dyn UpstreamDialer>) {

--- a/tunnel-lib/src/plugin/registry.rs
+++ b/tunnel-lib/src/plugin/registry.rs
@@ -27,6 +27,10 @@ pub struct PluginRegistry {
     /// Active route resolver.  Defaults to `NoRouteResolver` (fail-fast).
     pub route_resolver: Arc<dyn RouteResolver>,
 
+    /// Whether a real resolver has been installed via `set_route_resolver`.
+    /// Used by `validate_for_ingress` to detect misconfigured servers.
+    route_resolver_installed: bool,
+
     /// Egress dialers tried in registration order until `matches_scheme` returns true.
     pub dialers: Vec<Arc<dyn UpstreamDialer>>,
 
@@ -45,6 +49,7 @@ impl PluginRegistry {
             modules: Vec::new(),
             metrics_sink: Arc::new(NoopSink),
             route_resolver: Arc::new(NoRouteResolver),
+            route_resolver_installed: false,
             dialers: Vec::new(),
             lb: None,
             resolver: Arc::new(SystemResolver),
@@ -68,6 +73,7 @@ impl PluginRegistry {
 
     pub fn set_route_resolver(&mut self, resolver: Arc<dyn RouteResolver>) {
         self.route_resolver = resolver;
+        self.route_resolver_installed = true;
     }
 
     pub fn add_dialer(&mut self, dialer: Arc<dyn UpstreamDialer>) {
@@ -80,6 +86,25 @@ impl PluginRegistry {
 
     pub fn set_resolver(&mut self, resolver: Arc<dyn Resolver>) {
         self.resolver = resolver;
+    }
+
+    /// Assert that the registry is usable for server-side ingress dispatch.
+    ///
+    /// Fails fast at startup if critical pieces (ingress handlers or a real
+    /// route resolver) are missing — without this, a misconfigured server
+    /// would compile, start, and fail per-connection at runtime.
+    pub fn validate_for_ingress(&self) -> anyhow::Result<()> {
+        if self.ingress_handlers.is_empty() {
+            anyhow::bail!(
+                "PluginRegistry has no ingress handlers; register at least one via register_ingress_handler"
+            );
+        }
+        if !self.route_resolver_installed {
+            anyhow::bail!(
+                "PluginRegistry has no route resolver installed; call set_route_resolver before serving"
+            );
+        }
+        Ok(())
     }
 }
 

--- a/tunnel-lib/src/plugin/route.rs
+++ b/tunnel-lib/src/plugin/route.rs
@@ -1,0 +1,38 @@
+use anyhow::Result;
+use async_trait::async_trait;
+
+use super::ctx::{PhaseResult, Route, RouteCtx};
+
+/// Abstraction over route-resolution strategies.
+///
+/// Implementations live in `server/plugins/vhost/` (vhost lookup) and
+/// `server/plugins/static_port/` (direct group:proxy mapping).
+/// The CORE fallback is `StaticPortResolver`.
+#[async_trait]
+pub trait RouteResolver: Send + Sync + 'static {
+    /// Map an incoming connection to a `Route`.
+    ///
+    /// Returns `PhaseResult::Continue(route)` on success or
+    /// `PhaseResult::Reject` when no matching route is found.
+    async fn resolve(&self, ctx: &RouteCtx) -> Result<PhaseResult<Route>>;
+}
+
+/// CORE fallback resolver: always rejects (no route configured).
+///
+/// Used when no RouteResolver plugin is installed so that startup fails
+/// explicitly rather than silently routing nowhere.
+pub struct NoRouteResolver;
+
+#[async_trait]
+impl RouteResolver for NoRouteResolver {
+    async fn resolve(&self, ctx: &RouteCtx) -> Result<PhaseResult<Route>> {
+        Ok(PhaseResult::Reject {
+            status: 404,
+            message: format!(
+                "no RouteResolver configured for port {}",
+                ctx.listener_port
+            )
+            .into(),
+        })
+    }
+}

--- a/tunnel-lib/src/plugin/service.rs
+++ b/tunnel-lib/src/plugin/service.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 
-use super::ctx::{AdmissionReq, PhaseOutcome, PhaseResult};
+use super::ctx::{AdmissionReq, PhaseOutcome, PhaseResult, ServerCtx};
 
 /// Service-level strategy trait for the tunnel pipeline.
 ///
@@ -18,5 +18,10 @@ pub trait TunnelService: Send + Sync + 'static {
         req: &AdmissionReq,
     ) -> Result<PhaseResult>;
 
-    fn logging(&self, outcome: &PhaseOutcome);
+    /// Emit access logs / metrics after the tunnel closes.
+    ///
+    /// Implementations **must not panic** — the dispatcher calls this on
+    /// every path (success, admission reject, route reject, handler error)
+    /// and catches unwinds to protect the accept worker.
+    fn logging(&self, ctx: &ServerCtx, outcome: &PhaseOutcome);
 }

--- a/tunnel-lib/src/plugin/service.rs
+++ b/tunnel-lib/src/plugin/service.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 
-use super::ctx::{AdmissionReq, PhaseOutcome, PhaseResult, Route, RouteCtx};
+use super::ctx::{AdmissionReq, PhaseOutcome, PhaseResult};
 
 /// Service-level strategy trait for the tunnel pipeline.
 ///
@@ -9,36 +9,14 @@ use super::ctx::{AdmissionReq, PhaseOutcome, PhaseResult, Route, RouteCtx};
 /// The framework calls the methods in fixed phase order; implementations
 /// override only the phases they care about.
 ///
-/// Analogous to Pingora's `ProxyHttp` trait.
+/// Analogous to Pingora's `ProxyHttp` trait. Route resolution is owned by
+/// `RouteResolver` in the plugin registry, not this trait.
 #[async_trait]
 pub trait TunnelService: Send + Sync + 'static {
-    // ── Phase 2: Admission ────────────────────────────────────────────────────
-
-    /// Decide whether to accept the incoming connection.
-    ///
-    /// Return `PhaseResult::Reject` to close the connection immediately
-    /// (optionally with a status code and human-readable message in logs).
-    /// Return `PhaseResult::Continue(())` to advance to route resolution.
     async fn admission(
         &self,
         req: &AdmissionReq,
     ) -> Result<PhaseResult>;
 
-    // ── Phase 3: Route resolve ────────────────────────────────────────────────
-
-    /// Map the incoming connection to a `Route` (group_id + proxy_name).
-    ///
-    /// Return `PhaseResult::Continue(route)` on success, or
-    /// `PhaseResult::Reject` if no matching route exists.
-    async fn resolve_route(
-        &self,
-        ctx: &RouteCtx,
-    ) -> Result<PhaseResult<Route>>;
-
-    // ── Phase 5: Logging ──────────────────────────────────────────────────────
-
-    /// Emit access logs and metrics after the tunnel closes.
-    ///
-    /// This method must not fail — errors are swallowed by the framework.
     fn logging(&self, outcome: &PhaseOutcome);
 }


### PR DESCRIPTION
## Summary

Completes the ingress/egress plugin migration described in `docs/plugins.md`. Bundles PRs ②–⑥ into one branch (plus two rounds of review cleanup).

- **PR ②** — Extract TLS / H2c / H1 / TCP passthrough handlers from `server/handlers/http.rs` into `server/plugins/*`, add `IngressDispatcher` with O(1) `HashMap<ProtocolKind, _>` handler lookup.
- **PR ③** — `RouteResolver` wired through `PluginRegistry`; `VhostPlugin` replaces the inline `state.routing.load()` lookup; `TunnelService::resolve_route` dropped. `IngressDispatcher` carries the listener port so Phase 4 gets the right `RouteCtx`. `PortedTunnelService` removed.
- **PR ④** — `PrometheusSink` plugin; `DefaultTunnelService::logging` emits phase timing through the injected `MetricsSink`; `NoopSink` remains the fallback.
- **PR ⑤** — `RoundRobinLb` + `CachedResolver` under `client/plugins/`; `LocalProxyMap::from_config` takes `Arc<dyn LoadBalancer>` + `Arc<dyn Resolver>` and delegates pick/resolve. `UpstreamDialer` left unimplemented — the existing `UpstreamResolver`/`PeerKind` path is already the dialer seam per docs §4.12 (`#[doc(hidden)]` on the unused trait).
- **PR ⑥** — `ServerState::use_plugin_stack` and the legacy if/else HTTP dispatcher deleted (~390 lines). `plugin_registry` is a required `Arc<PluginRegistry>`.
- **Review + simplify passes** — `LoadBalancer::pick` returns `Option<usize>` (no more `ptr::eq` lookup); `CachedResolver` preserves full `Vec<SocketAddr>` and caps at 1024 entries; `IngressProtocolHandler::handle` takes `Option<Route>`; `TunnelService::logging` takes `&ServerCtx`; dispatcher wraps `logging` in `catch_unwind`; `MetricsSink` label keys are `&'static str`; `PluginRegistry::validate_for_ingress()` fails fast at startup. H2c is the only handler that holds its own `RouteResolver` — H2 multiplexes authorities on one TCP connection, so it re-resolves per request.

### Scope adjustments from the original design

- **No YAML plugin-name table** (`ingress_plugins: [...]`). Today each seam has exactly one implementation; adding string-name lookup is premature abstraction. A future PR can add it when a second plugin lands.
- **`UpstreamDialer` unused**: kept the trait for symmetry, `#[doc(hidden)]` with a note that it's reserved.

### Stats

+1207 / −489 across 25 files. `docs/plugins.md` progress table flipped to ✅ for PRs ①–⑥.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test --workspace --all-targets` — all tests pass (+5 new: `validate_for_ingress` x2, `no_route_resolver_rejects_with_404`, `RoundRobinLb` x2, `CachedResolver` IP literal)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] End-to-end: boot server + client in staging, drive an HTTPS + h2c + plain TCP tunnel, confirm vhost routing and metrics
- [ ] End-to-end: confirm `curl <metrics_port>/metrics` still reports `duotunnel_*` counters; new `duotunnel_ingress_total_ms` histogram present
- [ ] Misconfigure startup (no ingress handlers) → confirm `validate_for_ingress` fails fast with the expected message