### PR TITLE
fix(open_bi): restore slow-path ordering to pre-regression baseline

### DIFF
--- a/client/entry.rs
+++ b/client/entry.rs
@@ -9,8 +9,8 @@ use tokio::net::TcpStream;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 use tunnel_lib::{
-    detect_protocol_and_host, open_bi_guarded, relay_quic_to_tcp, run_accept_worker,
-    send_routing_info, OverloadLimits, PeekBufPool, RoutingInfo, TcpParams,
+    detect_protocol_and_host, maybe_slow_path, open_bi_guarded, relay_quic_to_tcp,
+    run_accept_worker, send_routing_info, OverloadLimits, PeekBufPool, RoutingInfo, TcpParams,
 };
 
 const EMFILE_BACKOFF: Duration = Duration::from_millis(100);
@@ -108,10 +108,14 @@ async fn handle_entry_connection(
             Some(c) => c,
             None => break,
         };
+        maybe_slow_path(
+            || conn.inflight.load(std::sync::atomic::Ordering::Relaxed),
+            overload,
+        )
+        .await;
         match open_bi_guarded(
             &conn.conn,
             &conn.inflight,
-            overload,
             open_stream_timeout,
             |_elapsed, _outcome| {},
         )

--- a/server/handlers/tcp.rs
+++ b/server/handlers/tcp.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use tokio::net::{TcpListener, TcpStream};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
-use tunnel_lib::{open_bi_guarded, proxy, run_accept_worker, OpenBiOutcome};
+use tunnel_lib::{maybe_slow_path, open_bi_guarded, proxy, run_accept_worker, OpenBiOutcome};
 
 pub async fn run_tcp_accept_loop(
     listener: Arc<TcpListener>,
@@ -72,12 +72,16 @@ async fn handle_tcp_connection(
         protocol,
         host,
     };
+    maybe_slow_path(
+        || selected.inflight.load(std::sync::atomic::Ordering::Relaxed),
+        &state.overload_limits,
+    )
+    .await;
     let open_timeout = Duration::from_millis(state.config.server.open_stream_timeout_ms);
     let _open_bi_guard = metrics::open_bi_begin(&selected.conn_id);
     let opened = open_bi_guarded(
         &selected.conn,
         &selected.inflight,
-        &state.overload_limits,
         open_timeout,
         |elapsed, outcome| {
             metrics::open_bi_observe_wait_ms(elapsed.as_secs_f64() * 1000.0);

--- a/server/plugins/h1/mod.rs
+++ b/server/plugins/h1/mod.rs
@@ -56,6 +56,16 @@ impl IngressProtocolHandler for H1Handler {
             .select_client_for_group(&group_id)
             .ok_or_else(|| anyhow::anyhow!("no client for group: {}", group_id))?;
 
+        // Yield if the selected QUIC connection is near its stream cap.
+        // Placed before `read_exact` so the scheduler round-trip overlaps
+        // with draining already-peeked bytes instead of sitting on the
+        // request's critical path — this restores the 9cdbe83 ordering.
+        tunnel_lib::maybe_slow_path(
+            || selected.inflight.load(std::sync::atomic::Ordering::Relaxed),
+            &ctx.overload,
+        )
+        .await;
+
         // Consume the peeked bytes from the stream before handing it to relay.
         let mut discard = vec![0u8; initial_data.len()];
         stream.read_exact(&mut discard).await?;
@@ -72,7 +82,6 @@ impl IngressProtocolHandler for H1Handler {
         let opened = tunnel_lib::open_bi_guarded(
             &selected.conn,
             &selected.inflight,
-            &ctx.overload,
             open_timeout,
             |_elapsed, _outcome| {},
         )

--- a/server/plugins/tcp_pass/mod.rs
+++ b/server/plugins/tcp_pass/mod.rs
@@ -54,11 +54,16 @@ impl IngressProtocolHandler for TcpPassHandler {
             host,
         };
 
+        tunnel_lib::maybe_slow_path(
+            || selected.inflight.load(std::sync::atomic::Ordering::Relaxed),
+            &ctx.overload,
+        )
+        .await;
+
         let open_timeout = Duration::from_millis(ctx.timeouts.open_stream_ms);
         let opened = tunnel_lib::open_bi_guarded(
             &selected.conn,
             &selected.inflight,
-            &ctx.overload,
             open_timeout,
             |_elapsed, _outcome| {},
         )

--- a/tunnel-lib/src/open_bi.rs
+++ b/tunnel-lib/src/open_bi.rs
@@ -1,8 +1,6 @@
 use crate::inflight::{begin_inflight, InflightCounter, InflightGuard};
-use crate::overload::{maybe_slow_path, OverloadLimits};
 use anyhow::anyhow;
 use quinn::{Connection, RecvStream, SendStream};
-use std::sync::atomic::Ordering;
 use std::time::{Duration, Instant};
 
 #[derive(Debug)]
@@ -21,27 +19,27 @@ pub struct OpenedStream {
     pub inflight: InflightGuard,
 }
 
-/// Open a bidirectional QUIC stream with overload protection.
+/// Open a bidirectional QUIC stream with overload-safe inflight accounting.
 ///
 /// Flow:
-/// 1. `maybe_slow_path(inflight, limits)` — yield/backoff if the
-///    connection is near its `max_concurrent_streams` cap.
-/// 2. `begin_inflight(inflight)` — take the slot reservation.
-/// 3. `timeout(open_bi)` — bounded wait for a stream.
-/// 4. `on_wait_done(elapsed, outcome)` — a zero-cost hook the caller
+/// 1. `begin_inflight(inflight)` — take the slot reservation.
+/// 2. `timeout(open_bi)` — bounded wait for a stream.
+/// 3. `on_wait_done(elapsed, outcome)` — a zero-cost hook the caller
 ///    can use to observe wait time / emit metrics.  Always invoked.
+///
+/// The caller is responsible for invoking `crate::maybe_slow_path` before
+/// this function when appropriate — doing it here would force the yield to
+/// happen after any caller-side work (e.g. draining peeked bytes), which
+/// adds a scheduler round-trip to the request's critical path under load.
 pub async fn open_bi_guarded<F>(
     conn: &Connection,
     inflight: &InflightCounter,
-    limits: &OverloadLimits,
     stream_timeout: Duration,
     on_wait_done: F,
 ) -> anyhow::Result<OpenedStream>
 where
     F: FnOnce(Duration, OpenBiOutcome),
 {
-    let counter = inflight.clone();
-    maybe_slow_path(move || counter.load(Ordering::Relaxed), limits).await;
     let guard = begin_inflight(inflight);
     let started = Instant::now();
     let result = tokio::time::timeout(stream_timeout, conn.open_bi()).await;


### PR DESCRIPTION
## Summary

Bench data at https://locustbaby.github.io/duotunnel/bench/#overview shows H1 p95 at 8k qps regressed from **20ms** (9cdbe83) to **60ms** (eb3296a). Root cause is a single ordering change in `eb3296a`: `maybe_slow_path` got folded into `tunnel_lib::open_bi_guarded`, so the yield now runs **after** the H1 handler's \`stream.read_exact\`. That places a scheduler round-trip directly on the request's critical path — at 8k qps the runqueue is deep enough to amortise into tens of ms of p95.

This PR pulls `maybe_slow_path` back out of `open_bi_guarded`. Each caller invokes it explicitly before opening the QUIC stream:

- \`server/plugins/h1/mod.rs\` — **the fix**: slow-path call placed **before** \`stream.read_exact\`, matching the 9cdbe83 ordering. \`read_exact\` drains already-peeked bytes, so overlapping the yield with it is effectively free.
- \`server/plugins/tcp_pass/mod.rs\`, \`server/handlers/tcp.rs\`, \`client/entry.rs\` — call placed immediately before \`open_bi_guarded\`. No behaviour change on these paths.
- \`tunnel-lib/src/open_bi.rs\` — drops the \`limits\` argument and the internal \`maybe_slow_path\` call. Doc comment updated.

Scoped deliberately to the regression only. Audit turned up other hot-path cuts (H1 discard buffer, H2c mutexes, \`src_addr\` clones); those are queued for a follow-up PR so the bench result on this change isn't contaminated.

## Test plan

- [ ] Rerun the 8k qps H1 bench on the branch. Target: p95 returns to ≤25ms.
- [ ] Spot-check TCP passthrough bench at the same rate — slow-path now runs slightly earlier there but no \`read_exact\` sits between, so delta should be ~0.