### PR TITLE
perf: stack-buffer peek drains + parking_lot in H2c

### DIFF
--- a/client/entry.rs
+++ b/client/entry.rs
@@ -135,8 +135,15 @@ async fn handle_entry_connection(
                 send_routing_info(&mut send, &routing_info).await?;
                 if !initial_bytes.is_empty() {
                     send.write_all(&initial_bytes).await?;
-                    let mut discard = vec![0u8; initial_bytes.len()];
-                    local_stream.read_exact(&mut discard).await?;
+                    // Drain the peeked bytes from the socket. Reuse the
+                    // shared peek pool to avoid a per-connection heap
+                    // allocation for the discard buffer.
+                    let mut discard_buf = peek_pool.take();
+                    let result = local_stream
+                        .read_exact(&mut discard_buf[..initial_bytes.len()])
+                        .await;
+                    peek_pool.put(discard_buf);
+                    result?;
                 }
                 let (sent, received) = relay_quic_to_tcp(recv, send, local_stream).await?;
                 debug!(

--- a/server/plugins/h1/mod.rs
+++ b/server/plugins/h1/mod.rs
@@ -67,8 +67,13 @@ impl IngressProtocolHandler for H1Handler {
         .await;
 
         // Consume the peeked bytes from the stream before handing it to relay.
-        let mut discard = vec![0u8; initial_data.len()];
-        stream.read_exact(&mut discard).await?;
+        // `initial_data.len()` ≤ `SNIFF_LIMIT` by construction (Phase 1 caps
+        // the peek at that size), so a stack buffer avoids a per-connection
+        // heap allocation.
+        let mut discard = [0u8; tunnel_lib::plugin::SNIFF_LIMIT];
+        stream
+            .read_exact(&mut discard[..initial_data.len()])
+            .await?;
 
         let routing_info = tunnel_lib::RoutingInfo {
             proxy_name: proxy_name.to_string(),

--- a/server/plugins/h2c/mod.rs
+++ b/server/plugins/h2c/mod.rs
@@ -5,8 +5,9 @@ use hyper::server::conn::http2::Builder as H2Builder;
 use hyper::service::service_fn;
 use hyper::{Request, Response};
 use hyper_util::rt::TokioIo;
+use parking_lot::Mutex;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use tokio::net::TcpStream;
 use tracing::debug;
 
@@ -91,7 +92,7 @@ impl IngressProtocolHandler for H2cHandler {
                 let route_host = host.split(':').next().unwrap_or(&host).to_ascii_lowercase();
 
                 if single_authority {
-                    let mut fa = first_authority.lock().unwrap();
+                    let mut fa = first_authority.lock();
                     match fa.as_ref() {
                         None => *fa = Some(route_host.clone()),
                         Some(pinned) if pinned != &route_host => {
@@ -108,7 +109,7 @@ impl IngressProtocolHandler for H2cHandler {
                     }
                 }
 
-                let cached_route = { route_cache.lock().unwrap().get(&route_host).cloned() };
+                let cached_route = { route_cache.lock().get(&route_host).cloned() };
                 let route_target = match cached_route {
                     Some(route) => route,
                     None => {
@@ -138,7 +139,6 @@ impl IngressProtocolHandler for H2cHandler {
                         };
                         route_cache
                             .lock()
-                            .unwrap()
                             .insert(route_host.clone(), resolved.clone());
                         resolved
                     }
@@ -160,7 +160,7 @@ impl IngressProtocolHandler for H2cHandler {
                 let (conn_group_id, proxy_name) =
                     (route_target.group_id.clone(), route_target.proxy_name.clone());
                 let (client_conn, h2_sender) = {
-                    let mut guard = sender_cache.lock().unwrap();
+                    let mut guard = sender_cache.lock();
                     if !guard.contains_key(&route_target) {
                         if let Some(selected) =
                             registry.select_client_for_group(&conn_group_id)
@@ -206,7 +206,7 @@ impl IngressProtocolHandler for H2cHandler {
                     Ok(resp) => Ok::<_, hyper::Error>(resp),
                     Err(e) => {
                         tracing::error!("L7 Proxy upstream error: {}", e);
-                        sender_cache.lock().unwrap().remove(&route_target);
+                        sender_cache.lock().remove(&route_target);
                         Ok(Response::builder()
                             .status(502)
                             .body(

--- a/tunnel-lib/src/plugin/dispatcher.rs
+++ b/tunnel-lib/src/plugin/dispatcher.rs
@@ -22,7 +22,11 @@ fn safe_logging(svc: &dyn TunnelService, ctx: &ServerCtx, outcome: &PhaseOutcome
     }
 }
 
-const SNIFF_LIMIT: usize = 256;
+/// Upper bound on bytes that Phase 1 peeks before producing a
+/// `ProtocolHint`. Exposed so ingress handlers can size stack buffers
+/// (e.g. for discarding peeked bytes before handing the stream to a
+/// relay) without hard-coding the number.
+pub const SNIFF_LIMIT: usize = 256;
 
 // ── Protocol sniff (Phase 1, CORE — not pluggable) ────────────────────────────
 

--- a/tunnel-lib/src/plugin/mod.rs
+++ b/tunnel-lib/src/plugin/mod.rs
@@ -32,7 +32,7 @@ pub use ctx::{
     AdmissionReq, ConnectInfo, DialCtx, EgressCtx, PhaseOutcome, PhaseTiming, PhaseResult,
     PickCtx, Route, RouteCtx, ServerCtx, Target, Timeouts,
 };
-pub use dispatcher::IngressDispatcher;
+pub use dispatcher::{IngressDispatcher, SNIFF_LIMIT};
 pub use egress::{Connected, LoadBalancer, Resolver, SystemResolver, UpstreamDialer};
 pub use ingress::{IngressProtocolHandler, ProtocolHint, ProtocolKind};
 pub use metrics::{MetricsSink, NoopSink};


### PR DESCRIPTION
## Summary

Three secondary hot-path cuts surfaced by the audit that fed into #32. Deliberately split into a separate PR so the 8k qps H1 bench on #32 stays uncontaminated — none of these are the p95 regression fix.

- **Export \`SNIFF_LIMIT\` from \`tunnel-lib::plugin\`**. Previously private to \`dispatcher.rs\`. Ingress handlers can now size stack buffers without hard-coding the number.
- **\`server/plugins/h1/mod.rs\`**: the per-connection \`discard\` buffer was \`vec![0u8; initial_data.len()]\`. \`initial_data.len() ≤ SNIFF_LIMIT\` by construction, so swap to a stack \`[0u8; SNIFF_LIMIT]\` and drain into the appropriate prefix. One heap allocation per H1 connection gone.
- **\`client/entry.rs\`**: same peek-drain pattern. The entry-side peek size is configurable (default 16 KiB), too large for a fixed stack buffer, so reuse the already-present \`peek_pool\` for the discard buffer. Amortises to zero per-request heap allocs once the pool is warm.
- **\`server/plugins/h2c/mod.rs\`**: swap \`std::sync::Mutex\` → \`parking_lot::Mutex\` on the three per-connection caches (\`first_authority\`, \`route_cache\`, \`sender_cache\`). Drops the \`.unwrap()\` on every \`lock()\`. The miss path in \`route_cache\` still uses two separate lock cycles because an \`async\` resolve cannot hold a guard across \`.await\`; \`parking_lot\` just makes each uncontended cycle a few nanoseconds cheaper.

## Test plan

- [ ] Once this + #32 land, rerun 8k qps H1 bench — expect p95 to track #32's result ±1ms (these cuts are ns-scale, not the main lever).
- [ ] H2c-specific bench (if one exists) to confirm parking_lot doesn't regress anything.