### PR TITLE
CI: avoid fixed frp benchmark ports

### DIFF
--- a/ci-helpers/k6/bench.js
+++ b/ci-helpers/k6/bench.js
@@ -21,9 +21,9 @@ function activeProfile() {
 }
 
 function filterCases(cases, profile) {
-  if (profile === '8k')        return cases.filter((c) => c.name.includes('_8000qps') && !c.name.startsWith('frp_'));
-  if (profile === 'core')      return cases.filter((c) => !c.name.includes('_8000qps') && !c.name.startsWith('frp_'));
-  if (profile === 'frp')       return cases.filter((c) => c.name.startsWith('frp_'));
+  if (profile === '8k')        return cases.filter((c) => c.name.includes('_8000qps') && c.tunnel !== 'frp');
+  if (profile === 'core')      return cases.filter((c) => !c.name.includes('_8000qps') && c.tunnel !== 'frp');
+  if (profile === 'frp')       return cases.filter((c) => c.tunnel === 'frp');
   if (profile === 'basic')     return cases.filter((c) => c.category === 'basic');
   if (profile === 'body_size') return cases.filter((c) => c.category === 'body_size');
   return cases;
@@ -112,10 +112,34 @@ function track(ok) {
   if (!ok) errCounters[sn].add(1);
 }
 
+function currentCase() {
+  const sn = exec.scenario.name;
+  return ACTIVE_CASES.find((c) => c.name === sn) || {};
+}
+
+function resolvePort(portSpec, fallback) {
+  if (typeof portSpec === 'number') return portSpec;
+  if (portSpec && typeof portSpec === 'object') {
+    const envPort = portSpec.env ? parseEnvPositiveInt(__ENV[portSpec.env]) : null;
+    if (envPort !== null) return envPort;
+    const defaultPort = parseEnvPositiveInt(portSpec.default);
+    if (defaultPort !== null) return defaultPort;
+  }
+  return fallback;
+}
+
+function casePort(name, fallback) {
+  return resolvePort(currentCase().ports?.[name], fallback);
+}
+
+function caseTunnel() {
+  return currentCase().tunnel || 'duotunnel';
+}
+
 export function ingressHttpGet() {
   const sn = exec.scenario.name;
   const id = `${__VU}-${__ITER}`;
-  const res = http.get(`http://echo.local:8080/?id=${id}`, {
+  const res = http.get(`http://echo.local:${casePort('ingress', 8080)}/?id=${id}`, {
     timeout: '10s',
     tags: { name: sn },
     responseType: 'text',
@@ -134,15 +158,14 @@ export function ingressMultihost() {
   const id = `${__VU}-${__ITER}`;
   const n = ((__VU - 1) % MULTIHOST_COUNT) + 1;
   const host = `echo-${String(n).padStart(2, '0')}.local`;
-  // DuoTunnel uses 8080, FRP uses 7800. Differentiate by scenario name.
-  const port = sn.startsWith('frp_') ? 7800 : 8080;
+  const port = casePort('ingress', 8080);
   const res = http.get(`http://${host}:${port}/?id=${id}&host=${host}`, {
     timeout: '10s',
     tags: { name: sn },
     responseType: 'text',
   });
 
-  const checkPrefix = sn.startsWith('frp_') ? 'frp ingress multihost' : 'ingress multihost';
+  const checkPrefix = caseTunnel() === 'frp' ? 'frp ingress multihost' : 'ingress multihost';
   const ok = check(res, {
     [`${checkPrefix} 200`]: (r) => r.status === 200,
     [`${checkPrefix} host echo`]: (r) => r.body && r.body.includes(host),
@@ -155,7 +178,7 @@ export function ingressMultihost() {
 export function ingressHttpGetKeepalive() {
   const sn = exec.scenario.name;
   const id = `${__VU}-${__ITER}`;
-  const res = http.get(`http://echo.local:7800/?id=${id}`, {
+  const res = http.get(`http://echo.local:${casePort('ingress', 8080)}/?id=${id}`, {
     timeout: '10s',
     tags: { name: sn },
     responseType: 'text',
@@ -173,7 +196,7 @@ export function egressMultihost() {
   const id = `${__VU}-${__ITER}`;
   const n = ((__VU - 1) % MULTIHOST_COUNT) + 1;
   const host = `echo-${String(n).padStart(2, '0')}.local`;
-  const res = http.get(`http://${host}:8082/?id=${id}&host=${host}`, {
+  const res = http.get(`http://${host}:${casePort('egress', 8082)}/?id=${id}&host=${host}`, {
     timeout: '10s',
     tags: { name: sn },
     responseType: 'text',
@@ -190,7 +213,7 @@ export function ingressHttpPost() {
   const sn = exec.scenario.name;
   const id = `${__VU}-${__ITER}`;
   const res = http.post(
-    'http://echo.local:8080/',
+    `http://echo.local:${casePort('ingress', 8080)}/`,
     JSON.stringify({ bench: 'ingress-post', id: id }),
     { headers: { 'Content-Type': 'application/json' }, timeout: '10s', tags: { name: sn }, responseType: 'text' },
   );
@@ -204,7 +227,7 @@ export function ingressHttpPost() {
 export function egressHttpGet() {
   const sn = exec.scenario.name;
   const id = `${__VU}-${__ITER}`;
-  const res = http.get(`http://echo.local:8082/?id=${id}`, {
+  const res = http.get(`http://echo.local:${casePort('egress', 8082)}/?id=${id}`, {
     timeout: '10s',
     tags: { name: sn },
     responseType: 'text',
@@ -220,7 +243,7 @@ export function egressHttpPost() {
   const sn = exec.scenario.name;
   const id = `${__VU}-${__ITER}`;
   const res = http.post(
-    'http://echo.local:8082/',
+    `http://echo.local:${casePort('egress', 8082)}/`,
     JSON.stringify({ bench: 'egress-post', id: id }),
     {
       headers: { 'Content-Type': 'application/json' },
@@ -239,7 +262,7 @@ export function egressHttpPost() {
 export function ingressPost1K() {
   const sn = exec.scenario.name;
   const res = http.post(
-    'http://echo.local:8080/',
+    `http://echo.local:${casePort('ingress', 8080)}/`,
     PAYLOAD_1K,
     {
       headers: { 'Content-Type': 'application/octet-stream' },
@@ -258,7 +281,7 @@ export function ingressPost1K() {
 export function ingressPost10K() {
   const sn = exec.scenario.name;
   const res = http.post(
-    'http://echo.local:8080/',
+    `http://echo.local:${casePort('ingress', 8080)}/`,
     PAYLOAD_10K,
     {
       headers: { 'Content-Type': 'application/octet-stream' },
@@ -277,7 +300,7 @@ export function ingressPost10K() {
 export function ingressPost100K() {
   const sn = exec.scenario.name;
   const res = http.post(
-    'http://echo.local:8080/',
+    `http://echo.local:${casePort('ingress', 8080)}/`,
     PAYLOAD_100K,
     {
       headers: { 'Content-Type': 'application/octet-stream' },
@@ -296,7 +319,7 @@ export function ingressPost100K() {
 export function egressPost10K() {
   const sn = exec.scenario.name;
   const res = http.post(
-    'http://echo.local:8082/',
+    `http://echo.local:${casePort('egress', 8082)}/`,
     PAYLOAD_10K,
     {
       headers: { 'Content-Type': 'application/octet-stream' },
@@ -314,7 +337,7 @@ export function egressPost10K() {
 
 export function wsIngress() {
   const sn = exec.scenario.name;
-  ws.connect('ws://ws.local:8080', { tags: { name: sn } }, function (socket) {
+  ws.connect(`ws://ws.local:${casePort('ws', 8080)}`, { tags: { name: sn } }, function (socket) {
     let counted = false;
 
     socket.setTimeout(function () {
@@ -346,7 +369,7 @@ export function wsMultiMsg() {
   let received = 0;
   let counted = false;
 
-  ws.connect('ws://ws.local:8080', { tags: { name: sn } }, function (socket) {
+  ws.connect(`ws://ws.local:${casePort('ws', 8080)}`, { tags: { name: sn } }, function (socket) {
     socket.setTimeout(function () {
       if (!counted) { reqCounters[sn].add(1); errCounters[sn].add(1); counted = true; }
       socket.close();
@@ -387,17 +410,20 @@ grpcLargeClient.load(['../proto'], 'grpc_echo.proto');
 const grpcHighQpsClient = new grpc.Client();
 grpcHighQpsClient.load(['../proto'], 'grpc_echo.proto');
 
+function grpcIngressTarget() {
+  return `grpc.local:${casePort('grpc', 8080)}`;
+}
 
 export function grpcHealthIngress() {
   const sn = exec.scenario.name;
-  if (__ITER === 0) grpcHealthClient.connect('grpc.local:8080', { plaintext: true, timeout: '5s' });
+  if (__ITER === 0) grpcHealthClient.connect(grpcIngressTarget(), { plaintext: true, timeout: '5s' });
   const resp = grpcHealthClient.invoke('grpc.health.v1.Health/Check', { service: '' }, { tags: { name: sn } });
   const ok = resp && resp.status === grpc.StatusOK;
   reqCounters[sn].add(1);
   if (!ok) {
     errCounters[sn].add(1);
     try { grpcHealthClient.close(); } catch (_) {}
-    grpcHealthClient.connect('grpc.local:8080', { plaintext: true, timeout: '5s' });
+    grpcHealthClient.connect(grpcIngressTarget(), { plaintext: true, timeout: '5s' });
   }
   check(resp, { 'grpc health OK': (r) => r && r.status === grpc.StatusOK });
 }
@@ -405,14 +431,14 @@ export function grpcHealthIngress() {
 export function grpcEchoIngress() {
   const sn = exec.scenario.name;
   const id = `${__VU}-${__ITER}`;
-  if (__ITER === 0) grpcEchoClient.connect('grpc.local:8080', { plaintext: true, timeout: '5s' });
+  if (__ITER === 0) grpcEchoClient.connect(grpcIngressTarget(), { plaintext: true, timeout: '5s' });
   const resp = grpcEchoClient.invoke('grpc_echo.v1.EchoService/Echo', { ping: id }, { tags: { name: sn } });
   const ok = resp && resp.status === grpc.StatusOK;
   reqCounters[sn].add(1);
   if (!ok) {
     errCounters[sn].add(1);
     try { grpcEchoClient.close(); } catch (_) {}
-    grpcEchoClient.connect('grpc.local:8080', { plaintext: true, timeout: '5s' });
+    grpcEchoClient.connect(grpcIngressTarget(), { plaintext: true, timeout: '5s' });
   }
   check(resp, {
     'grpc echo OK': (r) => r && r.status === grpc.StatusOK,
@@ -422,14 +448,14 @@ export function grpcEchoIngress() {
 
 export function grpcLargePayload() {
   const sn = exec.scenario.name;
-  if (__ITER === 0) grpcLargeClient.connect('grpc.local:8080', { plaintext: true, timeout: '5s' });
+  if (__ITER === 0) grpcLargeClient.connect(grpcIngressTarget(), { plaintext: true, timeout: '5s' });
   const resp = grpcLargeClient.invoke('grpc_echo.v1.EchoService/Echo', { ping: PAYLOAD_10K }, { tags: { name: sn } });
   const ok = resp && resp.status === grpc.StatusOK;
   reqCounters[sn].add(1);
   if (!ok) {
     errCounters[sn].add(1);
     try { grpcLargeClient.close(); } catch (_) {}
-    grpcLargeClient.connect('grpc.local:8080', { plaintext: true, timeout: '5s' });
+    grpcLargeClient.connect(grpcIngressTarget(), { plaintext: true, timeout: '5s' });
   }
   check(resp, {
     'grpc 10K OK': (r) => r && r.status === grpc.StatusOK,
@@ -440,14 +466,14 @@ export function grpcLargePayload() {
 export function grpcHighQps() {
   const sn = exec.scenario.name;
   const id = `${__VU}-${__ITER}`;
-  if (__ITER === 0) grpcHighQpsClient.connect('grpc.local:8080', { plaintext: true, timeout: '5s' });
+  if (__ITER === 0) grpcHighQpsClient.connect(grpcIngressTarget(), { plaintext: true, timeout: '5s' });
   const resp = grpcHighQpsClient.invoke('grpc_echo.v1.EchoService/Echo', { ping: id }, { tags: { name: sn } });
   const ok = resp && resp.status === grpc.StatusOK;
   reqCounters[sn].add(1);
   if (!ok) {
     errCounters[sn].add(1);
     try { grpcHighQpsClient.close(); } catch (_) {}
-    grpcHighQpsClient.connect('grpc.local:8080', { plaintext: true, timeout: '5s' });
+    grpcHighQpsClient.connect(grpcIngressTarget(), { plaintext: true, timeout: '5s' });
   }
   check(resp, {
     'grpc high qps OK': (r) => r && r.status === grpc.StatusOK,
@@ -458,12 +484,12 @@ export function grpcHighQps() {
 export function bidirectional() {
   const sn = exec.scenario.name;
   const id = `${__VU}-${__ITER}`;
-  const inRes = http.get(`http://echo.local:8080/?id=${id}`, {
+  const inRes = http.get(`http://echo.local:${casePort('ingress', 8080)}/?id=${id}`, {
     timeout: '10s',
     tags: { name: sn },
     responseType: 'text',
   });
-  const egRes = http.get(`http://echo.local:8082/?id=${id}`, {
+  const egRes = http.get(`http://echo.local:${casePort('egress', 8082)}/?id=${id}`, {
     timeout: '10s',
     tags: { name: sn },
     responseType: 'text',
@@ -482,7 +508,7 @@ export function bidirectional() {
 
 export function handleSummary(data) {
   const extras = {};
-  if (ACTIVE_CASES.length > 0 && ACTIVE_CASES.every(c => c.name.startsWith('frp_'))) {
+  if (ACTIVE_CASES.length > 0 && ACTIVE_CASES.every(c => c.tunnel === 'frp')) {
     extras.tunnel = 'frp';
   }
 

--- a/ci-helpers/k6/cases/defaults.json
+++ b/ci-helpers/k6/cases/defaults.json
@@ -8,6 +8,12 @@
     "httpReqFailed": "rate<0.05",
     "duration": "p(95)<60000"
   },
+  "ports": {
+    "ingress": {"env": "DUOTUNNEL_INGRESS_PORT", "default": 8080},
+    "egress": {"env": "DUOTUNNEL_EGRESS_PORT", "default": 8082},
+    "ws": {"env": "DUOTUNNEL_WS_PORT", "default": 8080},
+    "grpc": {"env": "DUOTUNNEL_GRPC_PORT", "default": 8080}
+  },
   "durationSec": 20,
   "includeInTotalRps": false
 }

--- a/ci-helpers/k6/cases/frp.json
+++ b/ci-helpers/k6/cases/frp.json
@@ -1,4 +1,10 @@
 {
+  "defaults": {
+    "tunnel": "frp",
+    "ports": {
+      "ingress": {"env": "FRP_HTTP_PORT", "default": 7800}
+    }
+  },
   "cases": [
     {
       "name": "frp_ingress_3000qps",

--- a/ci-helpers/k6/catalog.js
+++ b/ci-helpers/k6/catalog.js
@@ -22,7 +22,8 @@ function deepMerge(target, source) {
 }
 
 function processCases(input) {
-  return (input.cases || []).map(c => deepMerge(DEFAULTS, c));
+  const defaults = deepMerge(DEFAULTS, input.defaults || {});
+  return (input.cases || []).map(c => deepMerge(defaults, c));
 }
 
 export const ALL_CASES = [

--- a/ci-helpers/run-bench-case.sh
+++ b/ci-helpers/run-bench-case.sh
@@ -3,8 +3,51 @@ set -eo pipefail
 
 CASE_NAME=$1
 GITHUB_SHA=$2
-FRP_SERVER_PORT=7700
-FRP_HTTP_PORT=7800
+FRP_SERVER_PORT=${FRP_SERVER_PORT:-}
+FRP_HTTP_PORT=${FRP_HTTP_PORT:-}
+REQUESTED_FRP_SERVER_PORT="${FRP_SERVER_PORT}"
+REQUESTED_FRP_HTTP_PORT="${FRP_HTTP_PORT}"
+FRP_TMP_DIR=""
+FRPS_CONFIG="ci-helpers/configs/frps.toml"
+FRPC_CONFIG="ci-helpers/configs/frpc.toml"
+
+pick_frp_ports() {
+  if [ -n "${FRP_SERVER_PORT}" ] && [ -n "${FRP_HTTP_PORT}" ]; then
+    return 0
+  fi
+
+  read -r FRP_SERVER_PORT FRP_HTTP_PORT < <(python3 - <<'PY'
+import socket
+
+sockets = []
+for _ in range(2):
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    sockets.append(s)
+
+print(*(s.getsockname()[1] for s in sockets))
+PY
+)
+}
+
+prepare_frp_configs() {
+  rm -rf "${FRP_TMP_DIR:-}"
+  FRP_TMP_DIR=$(mktemp -d /tmp/duotunnel-frp.XXXXXX)
+  FRPS_CONFIG="${FRP_TMP_DIR}/frps.toml"
+  FRPC_CONFIG="${FRP_TMP_DIR}/frpc.toml"
+  sed \
+    -e "s/^bindPort = .*/bindPort = ${FRP_SERVER_PORT}/" \
+    -e "s/^vhostHTTPPort = .*/vhostHTTPPort = ${FRP_HTTP_PORT}/" \
+    ci-helpers/configs/frps.toml > "${FRPS_CONFIG}"
+  sed \
+    -e "s/^serverPort = .*/serverPort = ${FRP_SERVER_PORT}/" \
+    ci-helpers/configs/frpc.toml > "${FRPC_CONFIG}"
+}
+
+cleanup_frp_tmp() {
+  rm -rf "${FRP_TMP_DIR:-}"
+  FRP_TMP_DIR=""
+}
 
 cleanup_frp() {
   sudo systemctl stop frp-client.scope 2>/dev/null || true
@@ -14,13 +57,19 @@ cleanup_frp() {
   sudo systemctl reset-failed frp-client.scope frp-server.scope 2>/dev/null || true
   sudo pkill -x frpc 2>/dev/null || true
   sudo pkill -x frps 2>/dev/null || true
-  sudo fuser -k "${FRP_SERVER_PORT}/tcp" 2>/dev/null || true
-  sudo fuser -k "${FRP_HTTP_PORT}/tcp" 2>/dev/null || true
+  if [ -n "${FRP_SERVER_PORT}" ]; then sudo fuser -k "${FRP_SERVER_PORT}/tcp" 2>/dev/null || true; fi
+  if [ -n "${FRP_HTTP_PORT}" ]; then sudo fuser -k "${FRP_HTTP_PORT}/tcp" 2>/dev/null || true; fi
+}
+
+port_is_listening() {
+  ss -H -tln "sport = :$1" 2>/dev/null | grep -q .
 }
 
 wait_for_frp_ports_free() {
   for i in $(seq 1 20); do
-    ss -tln | grep -qE ":${FRP_SERVER_PORT}|:${FRP_HTTP_PORT}" || return 0
+    if ! port_is_listening "${FRP_SERVER_PORT}" && ! port_is_listening "${FRP_HTTP_PORT}"; then
+      return 0
+    fi
     sleep 0.5
   done
   return 1
@@ -28,7 +77,9 @@ wait_for_frp_ports_free() {
 
 dump_frp_port_diag() {
   echo "=== frp port diagnostics ==="
+  echo "frp server port: ${FRP_SERVER_PORT:-unset}, http port: ${FRP_HTTP_PORT:-unset}"
   sudo ss -tlnp "( sport = :${FRP_SERVER_PORT} or sport = :${FRP_HTTP_PORT} )" 2>/dev/null || true
+  sudo ss -tanp "( sport = :${FRP_SERVER_PORT} or sport = :${FRP_HTTP_PORT} )" 2>/dev/null || true
   sudo lsof -nP -iTCP:"${FRP_SERVER_PORT}" -iTCP:"${FRP_HTTP_PORT}" -sTCP:LISTEN 2>/dev/null || true
 }
 
@@ -38,21 +89,24 @@ start_frp_stack() {
 
   sudo systemd-run --scope --unit=frp-server --collect \
     -p CPUQuota=50% -p CPUWeight=1024 -p MemoryMax=2G -p MemoryLow=256M \
-    -- frps -c ci-helpers/configs/frps.toml >> /tmp/frps.log 2>&1 &
+    -- frps -c "${FRPS_CONFIG}" >> /tmp/frps.log 2>&1 &
 
-  for i in $(seq 1 10); do
+  for i in $(seq 1 20); do
     if sudo systemctl is-failed frp-server.scope > /dev/null 2>&1; then
       return 1
     fi
-    if ss -tln | grep -q ":${FRP_SERVER_PORT}"; then
+    if port_is_listening "${FRP_SERVER_PORT}" && port_is_listening "${FRP_HTTP_PORT}"; then
       break
     fi
     sleep 0.3
   done
+  if ! port_is_listening "${FRP_SERVER_PORT}" || ! port_is_listening "${FRP_HTTP_PORT}"; then
+    return 1
+  fi
 
   sudo systemd-run --scope --unit=frp-client --collect \
     -p CPUQuota=50% -p CPUWeight=1024 -p MemoryMax=2G -p MemoryLow=256M \
-    -- frpc -c ci-helpers/configs/frpc.toml >> /tmp/frpc.log 2>&1 &
+    -- frpc -c "${FRPC_CONFIG}" >> /tmp/frpc.log 2>&1 &
 
   for i in $(seq 1 20); do
     if sudo systemctl is-failed frp-server.scope > /dev/null 2>&1; then
@@ -71,23 +125,36 @@ start_frp_stack() {
 
 IS_FRP=0
 [[ "$CASE_NAME" == frp_* ]] && IS_FRP=1
+if [ "$IS_FRP" -eq 1 ]; then
+  trap 'cleanup_frp; cleanup_frp_tmp' EXIT
+fi
 
 if [ "$IS_FRP" -eq 1 ]; then
-  cleanup_frp
-  if ! wait_for_frp_ports_free; then
-    echo "WARNING: frp ports are still occupied after cleanup, skipping $CASE_NAME"
-    dump_frp_port_diag
-    exit 0
-  fi
-
   FRP_READY=0
   for attempt in $(seq 1 3); do
+    cleanup_frp
+    FRP_SERVER_PORT="${REQUESTED_FRP_SERVER_PORT}"
+    FRP_HTTP_PORT="${REQUESTED_FRP_HTTP_PORT}"
+    pick_frp_ports
+    prepare_frp_configs
+    echo "Starting frp attempt ${attempt} with server port ${FRP_SERVER_PORT}, http port ${FRP_HTTP_PORT}"
+    if ! wait_for_frp_ports_free; then
+      echo "WARNING: selected frp ports are occupied before start"
+      dump_frp_port_diag
+      cleanup_frp_tmp
+      FRP_SERVER_PORT=""
+      FRP_HTTP_PORT=""
+      continue
+    fi
     if start_frp_stack; then
       FRP_READY=1
       break
     fi
     cleanup_frp
     wait_for_frp_ports_free || true
+    cleanup_frp_tmp
+    FRP_SERVER_PORT=""
+    FRP_HTTP_PORT=""
     sleep 1
   done
 
@@ -98,6 +165,7 @@ if [ "$IS_FRP" -eq 1 ]; then
     echo "=== frp-client scope ===" && sudo systemctl status frp-client.scope 2>&1 | tail -20 || true
     echo "=== frps ===" && cat /tmp/frps.log || true
     echo "=== frpc ===" && cat /tmp/frpc.log || true
+    cleanup_frp_tmp
     exit 0
   fi
 fi
@@ -108,6 +176,7 @@ echo $! > "/tmp/collect-${CASE_NAME}.pid"
 (cd ci-helpers/k6 && k6 run \
   -e GITHUB_SHA="${GITHUB_SHA}" \
   -e BENCH_CASE="${CASE_NAME}" \
+  -e FRP_HTTP_PORT="${FRP_HTTP_PORT}" \
   -e BENCH_RESULT_PATH="/tmp/bench-results-${CASE_NAME}.json" \
   bench.js)
 
@@ -129,4 +198,5 @@ fi
 if [ "$IS_FRP" -eq 1 ]; then
   cleanup_frp
   wait_for_frp_ports_free || true
+  cleanup_frp_tmp
 fi


### PR DESCRIPTION
## Summary
- move k6 benchmark ports into case catalog defaults, with frp overriding ingress via FRP_HTTP_PORT
- generate temporary frp configs using dynamically selected control/http ports per benchmark case
- require both frps control and vhost HTTP ports to be listening before starting frpc, and clean up via trap

## Verification
- bash -n ci-helpers/run-bench-case.sh
- node --check ci-helpers/k6/bench.js
- JSON parse check for k6 case files
- git diff --check origin/main..HEAD