### PR TITLE
proxy: structure hot-path errors

### DIFF
--- a/client/app.rs
+++ b/client/app.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Result, anyhow};
 use bytes::Bytes;
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -7,11 +7,9 @@ use tracing::{debug, info};
 use tunnel_lib::plugin::{LoadBalancer, PickCtx, Resolver, Target};
 use tunnel_lib::proxy::core::{Context as ProxyContext, Protocol, UpstreamResolver};
 use tunnel_lib::proxy::http_connector::SharedHttpConnector;
-use tunnel_lib::proxy::peers::{
-    BasicPeerSpec, HttpPeerSpec, MitmPeerSpec, PeerSpec, TlsPeerSpec,
-};
+use tunnel_lib::proxy::peers::{BasicPeerSpec, HttpPeerSpec, MitmPeerSpec, PeerSpec, TlsPeerSpec};
 use tunnel_lib::proxy::tcp::UpstreamScheme;
-use tunnel_lib::{ClientConfig, HttpClientParams};
+use tunnel_lib::{ClientConfig, HttpClientParams, ProxyError};
 
 /// One named upstream group. `raw` is the source-of-truth address list in
 /// `scheme://host:port` form. `targets` is a parallel view built at config
@@ -108,15 +106,17 @@ impl ClientApp {
     }
 }
 impl UpstreamResolver for ClientApp {
-    async fn upstream_peer(&self, context: &mut ProxyContext) -> Result<PeerSpec> {
+    async fn upstream_peer(&self, context: &mut ProxyContext) -> Result<PeerSpec, ProxyError> {
         let routing = context
             .routing_info
             .as_ref()
-            .ok_or_else(|| anyhow!("missing routing info in context"))?;
+            .ok_or_else(ProxyError::routing_missing_info)?;
         let upstream_addr = self
             .map
             .get_local_address(&routing.proxy_name, context.client_addr)
-            .ok_or_else(|| anyhow::anyhow!("no upstream for proxy_name: {}", routing.proxy_name))?;
+            .ok_or_else(|| {
+                ProxyError::route_not_found(format!("proxy_name={}", routing.proxy_name))
+            })?;
         let (scheme, connect_addr_str, tls_host) = UpstreamScheme::from_address(&upstream_addr);
         let is_https = scheme.requires_tls();
         let http_scheme = if is_https { "https" } else { "http" };
@@ -140,12 +140,20 @@ impl UpstreamResolver for ClientApp {
             }
             Protocol::WebSocket => {
                 info!("WebSocket protocol detected, using TCP relay");
-                let target_addr = self.map.resolve_addr(&connect_addr_str).await?;
+                let target_addr = self
+                    .map
+                    .resolve_addr(&connect_addr_str)
+                    .await
+                    .map_err(|e| {
+                        ProxyError::resolve_upstream(format!("{connect_addr_str}: {e}"))
+                    })?;
                 let spec = BasicPeerSpec {
                     target_addr,
                     tls: if is_https {
                         Some(TlsPeerSpec {
-                            host: tls_host.ok_or_else(|| anyhow!("TLS host required for WSS"))?,
+                            host: tls_host.ok_or_else(|| {
+                                ProxyError::upstream_connect("TLS host required for WSS")
+                            })?,
                             alpn: None,
                         })
                     } else {
@@ -166,7 +174,13 @@ impl UpstreamResolver for ClientApp {
                     );
                     Ok(PeerSpec::MitmH2(spec))
                 } else {
-                    let target_addr = self.map.resolve_addr(&connect_addr_str).await?;
+                    let target_addr =
+                        self.map
+                            .resolve_addr(&connect_addr_str)
+                            .await
+                            .map_err(|e| {
+                                ProxyError::resolve_upstream(format!("{connect_addr_str}: {e}"))
+                            })?;
                     let spec = BasicPeerSpec {
                         target_addr,
                         tls: None,
@@ -174,7 +188,9 @@ impl UpstreamResolver for ClientApp {
                     Ok(PeerSpec::Tcp(spec))
                 }
             }
-            _ => Err(anyhow!("unsupported protocol")),
+            p => Err(ProxyError::unsupported_protocol(format!(
+                "client app: {p:?}"
+            ))),
         }
     }
 
@@ -184,19 +200,23 @@ impl UpstreamResolver for ClientApp {
         send: quinn::SendStream,
         recv: quinn::RecvStream,
         initial_data: Option<Bytes>,
-    ) -> Result<()> {
+    ) -> Result<(), ProxyError> {
         match peer {
             PeerSpec::Tcp(spec) => spec
-                .into_tcp_peer(self.tcp_params.clone())?
+                .into_tcp_peer(self.tcp_params.clone())
+                .map_err(|e| ProxyError::upstream_connect(e.to_string()))?
                 .connect_inner(send, recv, initial_data)
-                .await,
+                .await
+                .map_err(|e| ProxyError::upstream_forward(e.to_string())),
             PeerSpec::Http(spec) => self
                 .map
                 .http_connector
                 .connect(spec, send, recv, initial_data)
-                .await,
+                .await
+                .map_err(|e| ProxyError::http_upstream_request(e.to_string())),
             PeerSpec::MitmH2(spec) => {
-                let server_config = tunnel_lib::get_or_create_server_config(&spec.tls_host)?;
+                let server_config = tunnel_lib::get_or_create_server_config(&spec.tls_host)
+                    .map_err(|e| ProxyError::upstream_connect(e.to_string()))?;
                 let acceptor = tokio_rustls::TlsAcceptor::from(server_config);
                 let stream = tunnel_lib::QuinnStream { send, recv };
                 let stream = if let Some(init) = initial_data {
@@ -204,10 +224,9 @@ impl UpstreamResolver for ClientApp {
                 } else {
                     tunnel_lib::PrefixedReadWrite::new(stream, bytes::Bytes::new())
                 };
-                let accepted_stream = acceptor
-                    .accept(stream)
-                    .await
-                    .context("failed to accept ingress TLS for MITM")?;
+                let accepted_stream = acceptor.accept(stream).await.map_err(|e| {
+                    ProxyError::tls_handshake(format!("failed to accept ingress TLS for MITM: {e}"))
+                })?;
                 info!(
                     "MITM H2: TLS handshake accepted, starting H2 server for {}",
                     spec.tls_host
@@ -223,6 +242,7 @@ impl UpstreamResolver for ClientApp {
                         },
                     )
                     .await
+                    .map_err(|e| ProxyError::http_upstream_request(e.to_string()))
             }
         }
     }

--- a/client/entry.rs
+++ b/client/entry.rs
@@ -9,14 +9,19 @@ use tokio::net::TcpStream;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 use tunnel_lib::{
+    ErrorKind, OverloadLimits, PeekBufPool, ProxyError, RoutingInfo, TcpParams,
     detect_protocol_and_host, maybe_slow_path, open_bi_guarded, relay_quic_to_tcp,
-    run_accept_worker, send_routing_info, ErrorKind, OverloadLimits, PeekBufPool, ProxyError,
-    RoutingInfo, TcpParams,
+    run_accept_worker, send_routing_info,
 };
 
 const EMFILE_BACKOFF: Duration = Duration::from_millis(100);
 
 static ENTRY_PEEK_POOL: OnceLock<PeekBufPool> = OnceLock::new();
+
+fn with_conn_detail(conn_id: impl std::fmt::Display, err: ProxyError) -> ProxyError {
+    let detail = format!("conn_id={conn_id}: {err}");
+    err.with_detail(detail)
+}
 
 pub struct EntryListenerConfig {
     pub port: u16,
@@ -138,9 +143,6 @@ async fn handle_entry_connection(
                 send_routing_info(&mut send, &routing_info).await?;
                 if !initial_bytes.is_empty() {
                     send.write_all(&initial_bytes).await?;
-                    // Drain the peeked bytes from the socket. Reuse the
-                    // shared peek pool to avoid a per-connection heap
-                    // allocation for the discard buffer.
                     let mut discard_buf = peek_pool.take();
                     let result = local_stream
                         .read_exact(&mut discard_buf[..initial_bytes.len()])
@@ -155,47 +157,26 @@ async fn handle_entry_connection(
                 );
                 return Ok(());
             }
-            Err(e) => {
-                match e.kind {
-                    ErrorKind::QuicOpenTimeout => {
-                        warn!(error = %e, conn_id = conn.conn.stable_id(), "open_bi timed out, trying next connection");
-                        last_err = ProxyError {
-                            detail: Some(format!(
-                                "conn_id={}: {}",
-                                conn.conn.stable_id(),
-                                e
-                            )),
-                            ..e
-                        }
-                        .into();
-                    }
-                    ErrorKind::QuicOpenConnection => {
-                        warn!(error = %e, conn_id = conn.conn.stable_id(), "open_bi hit connection error, evicting stale pool entry");
-                        pool.remove(&conn.conn);
-                        last_err = ProxyError {
-                            detail: Some(format!(
-                                "conn_id={}: {}",
-                                conn.conn.stable_id(),
-                                e
-                            )),
-                            ..e
-                        }
-                        .into();
-                    }
-                    _ => {
-                        warn!(error = %e, conn_id = conn.conn.stable_id(), "open_bi failed, trying next connection");
-                        last_err = ProxyError {
-                            detail: Some(format!(
-                                "conn_id={}: {}",
-                                conn.conn.stable_id(),
-                                e
-                            )),
-                            ..e
-                        }
-                        .into();
-                    }
+            Err(e) => match e.kind {
+                ErrorKind::QuicStreamLimit => {
+                    warn!(error = %e, conn_id = conn.conn.stable_id(), "open_bi stream capacity unavailable, trying next connection");
+                    last_err = with_conn_detail(conn.conn.stable_id(), e).into();
                 }
-            }
+                ErrorKind::QuicConnectionLost => {
+                    warn!(error = %e, conn_id = conn.conn.stable_id(), "open_bi hit stale connection, evicting pool entry");
+                    pool.remove(&conn.conn);
+                    last_err = with_conn_detail(conn.conn.stable_id(), e).into();
+                }
+                ErrorKind::QuicConnectionFatal => {
+                    warn!(error = %e, conn_id = conn.conn.stable_id(), "open_bi hit fatal connection error");
+                    pool.remove(&conn.conn);
+                    return Err(with_conn_detail(conn.conn.stable_id(), e).into());
+                }
+                _ => {
+                    warn!(error = %e, conn_id = conn.conn.stable_id(), "open_bi failed, trying next connection");
+                    last_err = with_conn_detail(conn.conn.stable_id(), e).into();
+                }
+            },
         }
     }
     Err(last_err)

--- a/docs/donelist.md
+++ b/docs/donelist.md
@@ -24,6 +24,16 @@
 - [x] **CR-NEW-E — PeekBufPool 共享工具**: 提取 `infra::peek_buf::PeekBufPool`，`client/entry.rs` 与 `proxy/core.rs` 复用同一 thread-local buffer pool，集中维护 `set_len` 安全前提。
 - [x] **CR-NEW-C — TcpPeer/TlsTcpPeer 合并**: TCP peer 已收敛为 `TcpPeer { tls: Option<TlsConfig> }` / `BasicPeerSpec { tls: Option<TlsPeerSpec> }` 形态。
 
+## Pingora-inspired Proxy Refactor ✅
+
+- [x] **TODO-63 — Peer 描述符化**: 执行链路已从 `UpstreamResolver -> PeerKind` 切到 `UpstreamResolver -> PeerSpec -> connect_peer`，client MITM 路径不再依赖 `PeerKind::Dyn`。
+- [x] **TODO-65 — Hot-path structured errors**: `ProxyError / ErrorKind / ErrorSource / RetryType` 已覆盖 `open_bi_guarded`、server/client `UpstreamResolver`、H1/H2c/TLS/TCP ingress 热路径和共享 proxy error metrics。
+  - `open_bi` 已区分 stream capacity (`QuicStreamLimit`)、transient connection loss (`QuicConnectionLost`) 和 fatal connection error (`QuicConnectionFatal`)。
+  - `client/entry.rs` 根据结构化 QUIC open 错误做 next-connection retry、stale connection eviction 或 fatal fail-fast。
+  - `duotunnel_proxy_errors_total{protocol,type,source,retry}` 已接入 plugin dispatcher、h2c、TLS H2 和 legacy server handler 路径。
+  - 验证：`cargo check -p tunnel-lib -p server -p client`；`cargo test -p tunnel-lib -p server -p client`。
+- [x] **TODO-70 — Server snapshot 持 Arc<SelectedConnection>**: server 侧连接快照已与 client 侧共享/缓存语义对齐。
+
 ---
 
 ## Auth & Config Source Plan

--- a/docs/pingora-tasks.md
+++ b/docs/pingora-tasks.md
@@ -10,9 +10,11 @@
 >
 > **2026-04-24 进度同步**：`TODO-63` 已完成；`TODO-65` 已完成第一阶段；`TODO-66` Phase 1 已落地并接入 live path；`TODO-69` 第一阶段已有部分实现。当前执行链路已从 `UpstreamResolver -> PeerKind` 切到 `UpstreamResolver -> PeerSpec -> connect_peer`；client 侧 MITM 路径不再依赖 `PeerKind::Dyn`；HTTP upstream/H2 upstream 已统一走 `HttpConnector` Phase 1。编译验证已通过：`cargo check -p tunnel-lib -p server -p client`。
 >
-> **2026-04-26 代码核对修正**：本次对照实现再次确认后，文档中“`TODO-65` = Done”“`TODO-64` = In Progress”的写法过于乐观。实际状态更接近：`TODO-65` 为 **In Progress（Phase 1 Done）**，因为 `ProxyError` 已接入 `open_bi`/h2c/部分 upstream 路径，但 `UpstreamResolver` 等热路径边界仍大量使用 `anyhow`；`TODO-64` 仍是 **TODO**，仓库内尚未引入 `ids.rs`、`ClientId/GroupId/ReuseHash`。`TODO-66` 的 `prefer_h1` 记忆目前只覆盖 `HttpConnector::request()` 的 cleartext request path，`connect()` 入口仍主要按 `spec.protocol` 分派，故继续记为 Phase 1 进行中；`TODO-69` 已有 stale cache 失效和空 body 一次重试，但 cached value 仍未升级到 `SelectedConnectionHandle/Arc<SelectedConnection>`。
+> **2026-04-26 代码核对修正**：本次对照实现再次确认后，文档中“`TODO-65` = Done”“`TODO-64` = In Progress”的写法过于乐观。彼时状态更接近：`TODO-65` 为 **In Progress（Phase 1 Done）**，因为 `ProxyError` 已接入 `open_bi`/h2c/部分 upstream 路径，但 `UpstreamResolver` 等热路径边界仍大量使用 `anyhow`；`TODO-64` 仍是 **TODO**，仓库内尚未引入 `ids.rs`、`ClientId/GroupId/ReuseHash`。`TODO-66` 的 `prefer_h1` 记忆目前只覆盖 `HttpConnector::request()` 的 cleartext request path，`connect()` 入口仍主要按 `spec.protocol` 分派，故继续记为 Phase 1 进行中；`TODO-69` 已有 stale cache 失效和空 body 一次重试，但 cached value 仍未升级到 `SelectedConnectionHandle/Arc<SelectedConnection>`。
 >
 > **2026-04-26 当日追加进度**：随后继续实现后，`TODO-66` 又补了两步：H1 downstream 的 upstream request 已统一走 `HttpConnector::request()`，cleartext upstream 的空 body 请求在 h2c 失败后会自动回退到 H1 一次；`TODO-69` 的 h2c cache value 已从拆散的 `(conn_id, conn, sender)` 收口到 `CachedSender { selected: Arc<SelectedConnection>, sender }`；`TODO-70` 已完成；`TODO-72` 已进入进行中，已补 client 侧 exclude set、`stable_id` 去重索引，以及 entry retry loop 对 `QuicOpenTimeout / QuicOpenConnection` 的区别处理。
+>
+> **2026-05-01 进度同步**：`TODO-65` 已完成。`UpstreamResolver` 边界已切到 `ProxyError`，`open_bi` 已区分 stream capacity、transient connection loss、fatal connection error，server/client resolver 和 H1/H2c/TLS/TCP ingress 热路径已接入结构化错误；共享指标 `duotunnel_proxy_errors_total{protocol,type,source,retry}` 已覆盖 plugin dispatcher、h2c、TLS H2 和 legacy server handler 路径。验证已通过：`cargo check -p tunnel-lib -p server -p client` 与 `cargo test -p tunnel-lib -p server -p client`。
 >
 > **2026-05-01 文档队列同步**：未完成项已统一收敛到 `docs/todo.md`。本文件保留 Pingora 主线的详细设计与进度说明；如状态摘要冲突，以 `docs/todo.md` 的 active mainline 分组为准。已确认 `TODO-69` 当前代码已使用 `CachedSender { selected: Arc<SelectedConnection>, sender }`，剩余工作集中在 h2c state 收敛、非空 body replayability 与 failover 验证。
 
@@ -22,7 +24,7 @@
 
 - **Plugin 系统** `tunnel-lib/src/plugin/`：`dispatcher.rs`（6 相位管线）、`ingress.rs`（`IngressProtocolHandler` trait）、`egress.rs`（`LoadBalancer/UpstreamDialer/Resolver` trait）、`service.rs`（`TunnelService`）、`route.rs`（`RouteResolver`）、`ctx.rs`（`PhaseResult/ServerCtx/RouteCtx/Route/...`）、`metrics.rs`（`MetricsSink`）、`module.rs`（`ConnectionModule`）、`registry.rs`（`PluginRegistry`）
 - **Ingress 分派器** `tunnel-lib/src/plugin/dispatcher.rs:88-218`：sniff → pre_admission → admission → route → handle → logging
-- **UpstreamResolver trait** `tunnel-lib/src/proxy/core.rs:25-37`：`async fn upstream_peer(&self, ctx: &mut Context) -> Result<PeerSpec>` + `connect_peer(...)`
+- **UpstreamResolver trait** `tunnel-lib/src/proxy/core.rs:25-37`：`async fn upstream_peer(&self, ctx: &mut Context) -> Result<PeerSpec, ProxyError>` + `connect_peer(...) -> Result<(), ProxyError>`
   - server 实现 `server/egress.rs:65` `impl UpstreamResolver for ServerEgressMap`
   - client 实现 `client/app.rs:108` `impl UpstreamResolver for ClientApp`
 - **Ingress 插件** `server/plugins/{h1,h2c,tls,tcp_pass,vhost,prometheus}/mod.rs`
@@ -43,7 +45,7 @@
 |---|---|---|---|
 | [TODO-63](#todo-63-peer-描述符化--先消灭-peerkind--dyn-双轨) | Peer 描述符化 + 先消灭 `PeerKind + Dyn` 双轨 | High | Done |
 | [TODO-64](#todo-64-reusehash--clientidgroupid-newtype收尾类型安全) | ReuseHash + ClientId/GroupId newtype（收尾类型安全） | Medium | TODO |
-| [TODO-65](#todo-65-热路径结构化错误--先替换-anyhow-黑盒) | 热路径结构化错误 + 先替换 `anyhow` 黑盒 | High | In Progress（Phase 1 Done） |
+| [TODO-65](#todo-65-热路径结构化错误--先替换-anyhow-黑盒) | 热路径结构化错误 + 先替换 `anyhow` 黑盒 | High | Done |
 | [TODO-66](#todo-66-统一-httpconnector--h1h2-降级记忆替代-httppeerh2peer) | 统一 HttpConnector + H1/H2 降级记忆 | High | In Progress |
 | [TODO-67](#todo-67-servicea--serverapp-抽象统一-accept--handle) | ~~Service\<A\> + ServerApp 抽象~~ | — | **部分达成，剩余部分降级为 TODO-67b** |
 | [TODO-67b](#todo-67b-keep-alive-loop-下沉到-session-层) | keep-alive loop 下沉到 Session 层 | Medium | TODO |
@@ -54,7 +56,7 @@
 | [TODO-72](#todo-72-client-端小优化非紧急随手做) | Client 端小优化 | Low | In Progress |
 | [TODO-73](#todo-73-不要抄-pingora-的部分参考避坑) | 不要抄 Pingora 的部分（参考避坑） | FYI | — |
 
-**推荐落地顺序**：63 → 65 → 66 → 69 → 72 → 64 → 67b → 68 → 71。理由：先把 resolver 输出收敛成“纯描述符”，再补热路径错误语义，随后用最小改动落地 `HttpConnector` Phase 1，并把 h2c 的 sticky sender 补成可失效重选。`Client` 侧小优化现在也已经进入实施阶段，优先级高于 `newtype` 收尾；`TODO-70` 已完成，从主线顺序中移除。当前进度：`63`、`70` 已完成；`65` 第一阶段已完成但未全量替掉热路径边界的 `anyhow`；`66` Phase 1 继续推进中；`69` 第一阶段已继续收敛；`72` 已进入进行中。每个 TODO 完成后跑 CI stress phase，观察基准变化。
+**推荐落地顺序**：66 → 69 → 72 → 64 → 67b → 68 → 71。理由：`63`、`65`、`70` 已完成；后续先继续收敛 `HttpConnector` 与 h2c sticky sender/failover，再做 client 侧小优化和 newtype 收尾。每个 TODO 完成后跑 CI stress phase，观察基准变化。
 
 ---
 
@@ -212,7 +214,7 @@ impl PeerSpec {
 
 ## [TODO-65] 热路径结构化错误 + 先替换 `anyhow` 黑盒
 
-**Priority**: High | **Status**: In Progress（Phase 1 Done）
+**Priority**: High | **Status**: Done
 **依赖与影响**:
 - 依赖：—（可独立于 63/64 推进，但最好在 63 之后做，边界更清晰）
 - 被依赖：TODO-66（Connector 的 `ReusedOnly` 语义）、TODO-72（client retry 可使用结构化 QUIC open 错误，但不直接套 `ReusedOnly`）
@@ -291,15 +293,17 @@ Metrics 增加 error label：`error_total{type="ConnectTimeout", source="upstrea
 - `server/handlers/metrics.rs` / `client` 对应位置
 - 后续扩展：`tunnel-lib/src/ctld_proto.rs`、`tunnel-store/src/traits.rs`
 
-**实际进展（已完成第一阶段）**:
+**实际进展（已完成）**:
 1. 已新增 `tunnel-lib/src/error.rs`，提供最小 `ProxyError / ErrorKind / ErrorSource / RetryType`。
-2. `open_bi_guarded` 已改为返回 `ProxyError`，至少能区分 timeout 和 connection error。
-3. H1/H2 upstream 失败日志已改为结构化错误口径。
+2. `open_bi_guarded` 已改为返回 `ProxyError`，并区分 `QuicStreamLimit`、`QuicConnectionLost`、`QuicConnectionFatal`。
+3. H1/H2 upstream 失败日志已改为结构化错误口径，HTTP upstream request 保留 `RetryType::ReusedOnly` 语义给后续 Session/Connector 重试使用。
 4. h2c ingress 的 `400 / 404 / 421 / 502 / 503` 已统一走 `ProxyError -> error_response`。
-5. 但 `tunnel-lib/src/proxy/core.rs` 的 `UpstreamResolver` 以及不少外围路径仍使用 `anyhow::Result`，还不能算“热路径结构化错误”整体完成。
-6. `client/entry.rs` 已开始按 `QuicOpenTimeout / QuicOpenConnection` 区分处理，并在 connection error 时主动移除 stale pool entry；但更细的 `stream-limit` / fatal-vs-transient 分类仍未补齐。
+5. `tunnel-lib/src/proxy/core.rs` 的 `UpstreamResolver::upstream_peer` / `connect_peer` 已改为返回 `ProxyError`；server/client resolver 实现已把缺路由、DNS 解析、unsupported protocol、upstream connect/forward、HTTP request、MITM TLS handshake 等错误映射为结构化类型。
+6. `client/entry.rs` 已按 stream capacity、transient connection loss、fatal connection error 分类处理；connection-level 失败会移除 stale pool entry。
+7. plugin dispatcher、h2c、TLS H2 和 legacy server handler 路径已打共享 `duotunnel_proxy_errors_total{protocol,type,source,retry}` 指标。
+8. 外围路径（config/store/ctld 等）仍保留 `anyhow::Result`，不在热路径结构化错误的当前范围内。
 
-**Validation**: `cargo check -p tunnel-lib -p server -p client` 已通过。行为验证仍放在 `TODO-66/69` 后继续补充重试与 failover 测试。
+**Validation**: `cargo check -p tunnel-lib -p server -p client` 与 `cargo test -p tunnel-lib -p server -p client` 已通过。行为验证仍放在 `TODO-66/69` 后继续补充重试与 failover 测试。
 
 ---
 
@@ -802,10 +806,10 @@ pub fn pick_p2c<T>(items: &[T], inflight: impl Fn(&T) -> usize, healthy: impl Fn
 **实际进展（已完成一部分）**:
 1. `EntryConnPool::push` 已补 `HashSet<stable_id>`，去重不再线性扫描整池。
 2. `client/entry.rs` 的重试循环已带 exclude set，当前轮失败过的 QUIC 连接不会被重复挑中。
-3. `client/entry.rs` 已开始按 `QuicOpenTimeout / QuicOpenConnection` 区分处理，并在 connection error 时移除 stale pool entry。
-4. 但更完整的 fatal-vs-transient 分类，以及未来多 server group 分池，都还未展开。
+3. `client/entry.rs` 已按 `QuicStreamLimit` / `QuicConnectionLost` / `QuicConnectionFatal` 做更细分类，并在 connection-level 失败时移除 stale pool entry。
+4. 未来多 server group 分池还未展开。
 
-**Validation**: `cargo check -p tunnel-lib -p server -p client` 已通过。
+**Validation**: `cargo check -p tunnel-lib -p server -p client` 与 `cargo test -p tunnel-lib -p server -p client` 已通过。
 
 ---
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -22,20 +22,9 @@ After `dial9-tokio-telemetry` publishes a crates.io version that includes commit
 
 ## 1. Active Mainline: Pingora-Inspired HTTP / Proxy Refactor
 
-Recommended order: `65 -> 66 -> 69 -> 72 -> 64 -> 67b -> 68 -> 71`.
+Recommended order: `66 -> 69 -> 72 -> 64 -> 67b -> 68 -> 71`.
 
-### [TODO-65] Hot-path structured errors
-**Priority**: High | **Status**: In Progress (Phase 1 Done)
-
-**Current code state**:
-- `ProxyError / ErrorKind / ErrorSource / RetryType` exists in `tunnel-lib/src/error.rs`.
-- `open_bi_guarded` returns `ProxyError`.
-- h2c ingress maps structured errors to HTTP responses and metrics labels.
-
-**Remaining**:
-1. Replace `anyhow::Result` at hot-path boundaries such as `UpstreamResolver::upstream_peer` / `connect_peer`.
-2. Classify `QuicStreamLimit` / fatal-vs-transient connection errors instead of only `QuicOpenTimeout` / `QuicOpenConnection`.
-3. Extend metrics labels from h2c-only error counters to the shared proxy paths.
+Completed: `TODO-65` moved to `docs/donelist.md`.
 
 ### [TODO-66] Unified HttpConnector + H1/H2 fallback memory
 **Priority**: High | **Status**: In Progress
@@ -68,12 +57,11 @@ Recommended order: `65 -> 66 -> 69 -> 72 -> 64 -> 67b -> 68 -> 71`.
 
 **Current code state**:
 - `EntryConnPool` de-duplicates by `Connection::stable_id()`.
-- Entry retry uses an exclude set and distinguishes timeout vs connection error.
-- Connection errors evict stale pool entries.
+- Entry retry uses an exclude set and distinguishes stream capacity, transient connection loss, and fatal connection errors.
+- Connection-level failures evict stale pool entries.
 
 **Remaining**:
-1. Add finer fatal/transient classification once TODO-65 exposes it.
-2. Decide whether future multi-server HA needs grouped pools rather than the current flat pool.
+1. Decide whether future multi-server HA needs grouped pools rather than the current flat pool.
 
 ### [TODO-64] ClientId / GroupId / ProxyName / ReuseHash newtypes
 **Priority**: Medium | **Status**: TODO

--- a/server/egress.rs
+++ b/server/egress.rs
@@ -1,5 +1,4 @@
 use crate::config::ServerEgressUpstream;
-use anyhow::{anyhow, Result};
 use bytes::Bytes;
 use std::collections::HashMap;
 use tracing::{debug, info, warn};
@@ -7,7 +6,7 @@ use tunnel_lib::proxy::core::{Context, Protocol, UpstreamResolver};
 use tunnel_lib::proxy::http_connector::SharedHttpConnector;
 use tunnel_lib::proxy::peers::{BasicPeerSpec, HttpPeerSpec, PeerSpec, TlsPeerSpec};
 use tunnel_lib::proxy::tcp::UpstreamScheme;
-use tunnel_lib::{HttpClientParams, UpstreamGroup};
+use tunnel_lib::{HttpClientParams, ProxyError, UpstreamGroup};
 pub struct ServerEgressMap {
     upstreams: HashMap<String, UpstreamGroup>,
     http_rules: HashMap<String, String>,
@@ -63,19 +62,19 @@ impl ServerEgressMap {
     }
 }
 impl UpstreamResolver for ServerEgressMap {
-    async fn upstream_peer(&self, context: &mut Context) -> Result<PeerSpec> {
+    async fn upstream_peer(&self, context: &mut Context) -> Result<PeerSpec, ProxyError> {
         let routing = context
             .routing_info
             .as_ref()
-            .ok_or_else(|| anyhow!("missing routing info in context"))?;
+            .ok_or_else(ProxyError::routing_missing_info)?;
         let host_raw = routing
             .host
             .as_deref()
-            .ok_or_else(|| anyhow!("no host in routing info"))?;
+            .ok_or_else(ProxyError::routing_missing_host)?;
         let host = host_raw.split(':').next().unwrap_or(host_raw);
         let upstream_addr = self
             .get_upstream_address(host)
-            .ok_or_else(|| anyhow!("no egress route for host: {}", host))?;
+            .ok_or_else(|| ProxyError::route_not_found(format!("host={host}")))?;
         let (scheme, connect_addr_str, tls_host) = UpstreamScheme::from_address(&upstream_addr);
         let is_https = scheme.requires_tls();
         match context.protocol {
@@ -87,9 +86,15 @@ impl UpstreamResolver for ServerEgressMap {
                 } else {
                     tokio::net::lookup_host(&connect_addr_str)
                         .await
-                        .map_err(|e| anyhow!("failed to resolve: {}: {}", connect_addr_str, e))?
+                        .map_err(|e| {
+                            ProxyError::resolve_upstream(format!("{connect_addr_str}: {e}"))
+                        })?
                         .next()
-                        .ok_or_else(|| anyhow!("no resolved IP for {}", connect_addr_str))?
+                        .ok_or_else(|| {
+                            ProxyError::resolve_upstream(format!(
+                                "no resolved IP for {connect_addr_str}"
+                            ))
+                        })?
                 };
                 let spec = BasicPeerSpec {
                     target_addr,
@@ -116,7 +121,9 @@ impl UpstreamResolver for ServerEgressMap {
                 };
                 Ok(PeerSpec::Http(spec))
             }
-            _ => Err(anyhow!("unsupported protocol for egress")),
+            p => Err(ProxyError::unsupported_protocol(format!(
+                "server egress: {p:?}"
+            ))),
         }
     }
 
@@ -126,21 +133,27 @@ impl UpstreamResolver for ServerEgressMap {
         send: quinn::SendStream,
         recv: quinn::RecvStream,
         initial_data: Option<Bytes>,
-    ) -> Result<()> {
+    ) -> Result<(), ProxyError> {
         match peer {
-            PeerSpec::Tcp(spec) => {
-                spec.into_tcp_peer(tunnel_lib::TcpParams::default())?
-                    .connect_inner(send, recv, initial_data)
-                    .await
-            }
+            PeerSpec::Tcp(spec) => spec
+                .into_tcp_peer(tunnel_lib::TcpParams::default())
+                .map_err(|e| ProxyError::upstream_connect(e.to_string()))?
+                .connect_inner(send, recv, initial_data)
+                .await
+                .map_err(|e| ProxyError::upstream_forward(e.to_string())),
             PeerSpec::Http(spec) => match spec.protocol {
                 Protocol::H2 | Protocol::H1 | Protocol::Unknown => self
                     .http_connector
                     .connect(spec, send, recv, initial_data)
-                    .await,
-                _ => Err(anyhow!("unsupported http protocol variant")),
+                    .await
+                    .map_err(|e| ProxyError::http_upstream_request(e.to_string())),
+                p => Err(ProxyError::unsupported_protocol(format!(
+                    "server http peer: {p:?}"
+                ))),
             },
-            PeerSpec::MitmH2(_) => Err(anyhow!("server egress does not support MITM peer")),
+            PeerSpec::MitmH2(_) => Err(ProxyError::unsupported_protocol(
+                "server egress does not support MITM peer",
+            )),
         }
     }
 }
@@ -150,7 +163,7 @@ impl UpstreamResolver for ServerEgressMap {
 pub struct EgressProxy(pub std::sync::Arc<ServerEgressMap>);
 
 impl UpstreamResolver for EgressProxy {
-    async fn upstream_peer(&self, context: &mut Context) -> Result<PeerSpec> {
+    async fn upstream_peer(&self, context: &mut Context) -> Result<PeerSpec, ProxyError> {
         self.0.upstream_peer(context).await
     }
 
@@ -160,7 +173,7 @@ impl UpstreamResolver for EgressProxy {
         send: quinn::SendStream,
         recv: quinn::RecvStream,
         initial_data: Option<Bytes>,
-    ) -> Result<()> {
+    ) -> Result<(), ProxyError> {
         self.0.connect_peer(peer, send, recv, initial_data).await
     }
 }

--- a/server/handlers/http.rs
+++ b/server/handlers/http.rs
@@ -1,4 +1,4 @@
-use crate::{metrics, ServerState};
+use crate::{ServerState, metrics};
 use anyhow::Result;
 use std::sync::Arc;
 use std::time::Duration;

--- a/server/handlers/tcp.rs
+++ b/server/handlers/tcp.rs
@@ -1,11 +1,11 @@
-use crate::{metrics, ServerState};
+use crate::{ServerState, metrics};
 use anyhow::Result;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::net::{TcpListener, TcpStream};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
-use tunnel_lib::{maybe_slow_path, open_bi_guarded, proxy, run_accept_worker, OpenBiOutcome};
+use tunnel_lib::{OpenBiOutcome, maybe_slow_path, open_bi_guarded, proxy, run_accept_worker};
 
 pub async fn run_tcp_accept_loop(
     listener: Arc<TcpListener>,
@@ -36,7 +36,7 @@ pub async fn run_tcp_accept_loop(
                 let result = handle_tcp_connection(state, stream, proxy_name, group_id).await;
                 if let Err(e) = &result {
                     debug!(error = %e, "TCP connection error");
-                    metrics::request_completed("tcp", "error");
+                    metrics::request_failed("tcp", e);
                 } else {
                     metrics::request_completed("tcp", "success");
                 }
@@ -85,8 +85,8 @@ async fn handle_tcp_connection(
         open_timeout,
         |elapsed, outcome| {
             metrics::open_bi_observe_wait_ms(elapsed.as_secs_f64() * 1000.0);
-            if matches!(outcome, OpenBiOutcome::Timeout) {
-                metrics::open_bi_timeout();
+            if matches!(outcome, OpenBiOutcome::StreamLimit) {
+                metrics::open_bi_stream_limit();
             }
         },
     )

--- a/server/metrics.rs
+++ b/server/metrics.rs
@@ -1,12 +1,13 @@
+use crate::plugins::prometheus::PrometheusSink;
 use metrics_exporter_prometheus::PrometheusHandle;
 use std::sync::OnceLock;
+use tunnel_lib::ProxyError;
 
 static HANDLE: OnceLock<PrometheusHandle> = OnceLock::new();
 
 pub fn set_handle(handle: PrometheusHandle) {
     HANDLE.set(handle).ok();
 }
-
 
 pub fn encode() -> String {
     HANDLE.get().map(|h| h.render()).unwrap_or_default()
@@ -31,25 +32,36 @@ pub fn tcp_connection_closed() {
 }
 
 pub fn auth_success(group_id: &str) {
-    metrics::counter!("duotunnel_auth_success_total", "group_id" => group_id.to_string()).increment(1);
+    metrics::counter!("duotunnel_auth_success_total", "group_id" => group_id.to_string())
+        .increment(1);
 }
 
 pub fn auth_failure(group_id: &str) {
-    metrics::counter!("duotunnel_auth_failure_total", "group_id" => group_id.to_string()).increment(1);
+    metrics::counter!("duotunnel_auth_failure_total", "group_id" => group_id.to_string())
+        .increment(1);
 }
 
 pub fn client_registered(group_id: &str) {
-    metrics::gauge!("duotunnel_clients_per_group", "group_id" => group_id.to_string()).increment(1.0);
+    metrics::gauge!("duotunnel_clients_per_group", "group_id" => group_id.to_string())
+        .increment(1.0);
 }
 
 pub fn client_unregistered(group_id: &str) {
-    metrics::gauge!("duotunnel_clients_per_group", "group_id" => group_id.to_string()).decrement(1.0);
+    metrics::gauge!("duotunnel_clients_per_group", "group_id" => group_id.to_string())
+        .decrement(1.0);
 }
 
 pub fn request_completed(protocol: &'static str, status: &'static str) {
-    metrics::counter!("duotunnel_requests_total", "protocol" => protocol, "status" => status).increment(1);
+    metrics::counter!("duotunnel_requests_total", "protocol" => protocol, "status" => status)
+        .increment(1);
 }
 
+pub fn request_failed(protocol: &'static str, error: &anyhow::Error) {
+    request_completed(protocol, "error");
+    if let Some(proxy_error) = error.downcast_ref::<ProxyError>() {
+        tunnel_lib::plugin::observe_proxy_error(&PrometheusSink, protocol, proxy_error);
+    }
+}
 
 pub struct OpenBiInflightGuard;
 
@@ -69,6 +81,6 @@ pub fn open_bi_observe_wait_ms(wait_ms: f64) {
     metrics::histogram!("duotunnel_open_bi_wait_ms").record(wait_ms);
 }
 
-pub fn open_bi_timeout() {
-    metrics::counter!("duotunnel_open_bi_timeout_total").increment(1);
+pub fn open_bi_stream_limit() {
+    metrics::counter!("duotunnel_open_bi_stream_limit_total").increment(1);
 }

--- a/server/plugins/h1/mod.rs
+++ b/server/plugins/h1/mod.rs
@@ -5,6 +5,7 @@ use tokio::io::AsyncReadExt;
 use tokio::net::TcpStream;
 use tracing::debug;
 
+use tunnel_lib::ProxyError;
 use tunnel_lib::plugin::{IngressProtocolHandler, ProtocolKind, Route, ServerCtx};
 
 use crate::registry::SharedRegistry;
@@ -29,16 +30,16 @@ impl IngressProtocolHandler for H1Handler {
         route: Option<Route>,
         ctx: &ServerCtx,
     ) -> Result<()> {
-        let route = route.ok_or_else(|| anyhow::anyhow!("H1Handler: missing Route"))?;
+        let route = route.ok_or_else(ProxyError::routing_missing_info)?;
         let hint = ctx
             .hint
             .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("H1Handler: missing ProtocolHint"))?;
+            .ok_or_else(ProxyError::routing_missing_info)?;
 
         let host = hint
             .authority
             .clone()
-            .ok_or_else(|| anyhow::anyhow!("no Host header in plaintext request"))?;
+            .ok_or_else(ProxyError::routing_missing_host)?;
 
         let initial_data: Vec<u8> = hint.raw_preface.to_vec();
         let protocol = match hint.protocol {
@@ -54,7 +55,7 @@ impl IngressProtocolHandler for H1Handler {
         let selected = self
             .registry
             .select_client_for_group(&group_id)
-            .ok_or_else(|| anyhow::anyhow!("no client for group: {}", group_id))?;
+            .ok_or_else(|| ProxyError::no_client_available(group_id.to_string()))?;
 
         // Yield if the selected QUIC connection is near its stream cap.
         // Placed before `read_exact` so the scheduler round-trip overlaps

--- a/server/plugins/h2c/mod.rs
+++ b/server/plugins/h2c/mod.rs
@@ -12,12 +12,12 @@ use std::sync::Arc;
 use tokio::net::TcpStream;
 use tracing::debug;
 
+use tunnel_lib::ProxyError;
 use tunnel_lib::plugin::{
     IngressProtocolHandler, PhaseResult, ProtocolHint, ProtocolKind, Route, RouteCtx,
     RouteResolver, ServerCtx,
 };
 use tunnel_lib::transport::listener::RouteTarget;
-use tunnel_lib::{ErrorKind, ErrorSource, ProxyError};
 
 use crate::registry::{SelectedConnection, SharedRegistry};
 
@@ -35,9 +35,7 @@ struct RetryableRequest {
     headers: hyper::HeaderMap,
 }
 
-fn error_response(
-    err: &ProxyError,
-) -> Response<tunnel_lib::proxy::h2_proxy::BoxBody> {
+fn error_response(err: &ProxyError) -> Response<tunnel_lib::proxy::h2_proxy::BoxBody> {
     let status = err.http_status().unwrap_or(StatusCode::BAD_GATEWAY);
     Response::builder()
         .status(status)
@@ -47,28 +45,6 @@ fn error_response(
                 .boxed(),
         )
         .unwrap()
-}
-
-fn error_kind_label(kind: ErrorKind) -> &'static str {
-    match kind {
-        ErrorKind::QuicOpenTimeout => "quic_open_timeout",
-        ErrorKind::QuicOpenConnection => "quic_open_connection",
-        ErrorKind::HttpUpstreamRequest => "http_upstream_request",
-        ErrorKind::H2cMissingAuthority => "h2c_missing_authority",
-        ErrorKind::H2cMisdirected => "h2c_misdirected",
-        ErrorKind::H2cRouteResolve => "h2c_route_resolve",
-        ErrorKind::H2cNoRoute => "h2c_no_route",
-        ErrorKind::H2cNoClient => "h2c_no_client",
-        ErrorKind::H2cForward => "h2c_forward",
-    }
-}
-
-fn error_source_label(source: ErrorSource) -> &'static str {
-    match source {
-        ErrorSource::Upstream => "upstream",
-        ErrorSource::Downstream => "downstream",
-        ErrorSource::Internal => "internal",
-    }
 }
 
 fn error_status_label(err: &ProxyError) -> &'static str {
@@ -83,16 +59,15 @@ fn error_status_label(err: &ProxyError) -> &'static str {
     }
 }
 
-fn observe_h2c_error(
-    metrics: &Arc<dyn tunnel_lib::plugin::MetricsSink>,
-    err: &ProxyError,
-) {
+fn observe_h2c_error(metrics: &Arc<dyn tunnel_lib::plugin::MetricsSink>, err: &ProxyError) {
+    tunnel_lib::plugin::observe_proxy_error(metrics.as_ref(), ProtocolKind::H2c.as_label(), err);
     metrics.incr(
         "duotunnel_h2c_errors_total",
         &[
             ("status", error_status_label(err)),
-            ("type", error_kind_label(err.kind)),
-            ("source", error_source_label(err.source)),
+            ("type", err.kind.as_label()),
+            ("source", err.source().as_label()),
+            ("retry", err.retry().as_label()),
         ],
     );
 }
@@ -277,9 +252,7 @@ impl IngressProtocolHandler for H2cHandler {
                     match get_or_create_sender(&sender_cache, &registry, &route_target) {
                         Some(entry) => entry,
                         None => {
-                            let err = ProxyError::h2c_no_client(
-                                route_target.group_id.to_string(),
-                            );
+                            let err = ProxyError::h2c_no_client(route_target.group_id.to_string());
                             observe_h2c_error(&metrics, &err);
                             return Ok(error_response(&err));
                         }
@@ -326,10 +299,7 @@ impl IngressProtocolHandler for H2cHandler {
                             if let Some(retry_entry) =
                                 get_or_create_sender(&sender_cache, &registry, &route_target)
                             {
-                                metrics.incr(
-                                    "duotunnel_h2c_retry_total",
-                                    &[("result", "attempt")],
-                                );
+                                metrics.incr("duotunnel_h2c_retry_total", &[("result", "attempt")]);
                                 let retry_req = build_retry_request(template);
                                 match tunnel_lib::forward_h2_request(
                                     &retry_entry.selected.conn,
@@ -356,8 +326,7 @@ impl IngressProtocolHandler for H2cHandler {
                                             &route_target,
                                             retry_entry.selected.conn.stable_id(),
                                         );
-                                        let err =
-                                            ProxyError::h2c_forward(retry_err.to_string());
+                                        let err = ProxyError::h2c_forward(retry_err.to_string());
                                         observe_h2c_error(&metrics, &err);
                                         tracing::error!(
                                             kind = ?err.kind,
@@ -383,7 +352,7 @@ impl IngressProtocolHandler for H2cHandler {
         H2Builder::new(hyper_util::rt::TokioExecutor::new())
             .serve_connection(io, service)
             .await
-            .map_err(|e| anyhow::anyhow!("H2 connection error: {}", e))?;
+            .map_err(|e| ProxyError::downstream_connection(format!("H2 connection error: {e}")))?;
         Ok(())
     }
 }

--- a/server/plugins/tcp_pass/mod.rs
+++ b/server/plugins/tcp_pass/mod.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use tokio::net::TcpStream;
 use tracing::debug;
 
+use tunnel_lib::ProxyError;
 use tunnel_lib::plugin::{IngressProtocolHandler, ProtocolKind, Route, ServerCtx};
 
 use crate::registry::SharedRegistry;
@@ -21,18 +22,11 @@ impl IngressProtocolHandler for TcpPassHandler {
         ProtocolKind::Tcp
     }
 
-    async fn handle(
-        &self,
-        stream: TcpStream,
-        route: Option<Route>,
-        ctx: &ServerCtx,
-    ) -> Result<()> {
-        let route = route.ok_or_else(|| anyhow::anyhow!("TcpPassHandler: missing Route"))?;
+    async fn handle(&self, stream: TcpStream, route: Option<Route>, ctx: &ServerCtx) -> Result<()> {
+        let route = route.ok_or_else(ProxyError::routing_missing_info)?;
         let hint = ctx.hint.as_ref();
         let host = hint.and_then(|h| h.sni.clone().or_else(|| h.authority.clone()));
-        let initial_data = hint
-            .map(|h| h.raw_preface.to_vec())
-            .unwrap_or_default();
+        let initial_data = hint.map(|h| h.raw_preface.to_vec()).unwrap_or_default();
 
         debug!(
             host = ?host,
@@ -44,7 +38,7 @@ impl IngressProtocolHandler for TcpPassHandler {
         let selected = self
             .registry
             .select_client_for_group(&group_id)
-            .ok_or_else(|| anyhow::anyhow!("no client for group: {}", group_id))?;
+            .ok_or_else(|| ProxyError::no_client_available(group_id.to_string()))?;
 
         let routing_info = tunnel_lib::RoutingInfo {
             proxy_name: proxy_name.to_string(),
@@ -73,12 +67,6 @@ impl IngressProtocolHandler for TcpPassHandler {
         let recv = opened.recv;
         let _inflight_guard = opened.inflight;
         tunnel_lib::send_routing_info(&mut send, &routing_info).await?;
-        tunnel_lib::proxy::forward_to_client(
-            send,
-            recv,
-            stream,
-            ctx.relay_buf_size,
-        )
-        .await
+        tunnel_lib::proxy::forward_to_client(send, recv, stream, ctx.relay_buf_size).await
     }
 }

--- a/server/plugins/tls/mod.rs
+++ b/server/plugins/tls/mod.rs
@@ -3,17 +3,16 @@ use async_trait::async_trait;
 use http_body_util::{BodyExt, Full};
 use hyper::server::conn::http2::Builder as H2Builder;
 use hyper::service::service_fn;
-use hyper::{Request, Response};
+use hyper::{Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
 use tokio::net::TcpStream;
 use tracing::{debug, info};
 
+use tunnel_lib::ProxyError;
 use tunnel_lib::plugin::{IngressProtocolHandler, ProtocolKind, Route, ServerCtx};
 
 use crate::registry::SharedRegistry;
 
-/// Terminates TLS (self-signed cert via PKI cache), then serves the inner
-/// connection as HTTP/2 with authority rewriting via the QUIC tunnel.
 pub struct TlsHandler {
     pub registry: SharedRegistry,
 }
@@ -24,23 +23,22 @@ impl IngressProtocolHandler for TlsHandler {
         ProtocolKind::Tls
     }
 
-    async fn handle(
-        &self,
-        stream: TcpStream,
-        route: Option<Route>,
-        ctx: &ServerCtx,
-    ) -> Result<()> {
-        let route = route.ok_or_else(|| anyhow::anyhow!("TlsHandler: missing Route"))?;
+    async fn handle(&self, stream: TcpStream, route: Option<Route>, ctx: &ServerCtx) -> Result<()> {
+        let route = route.ok_or_else(ProxyError::routing_missing_info)?;
         let host = ctx
             .hint
             .as_ref()
             .and_then(|h| h.sni.clone())
-            .ok_or_else(|| anyhow::anyhow!("TlsHandler: no SNI in ProtocolHint"))?;
+            .ok_or_else(ProxyError::routing_missing_host)?;
 
         debug!(host = %host, "TLS connection: terminating");
-        let server_config = tunnel_lib::infra::pki::get_or_create_server_config(&host)?;
+        let server_config = tunnel_lib::infra::pki::get_or_create_server_config(&host)
+            .map_err(|e| ProxyError::tls_handshake(format!("server config for {host}: {e}")))?;
         let acceptor = tokio_rustls::TlsAcceptor::from(server_config);
-        let tls_stream = acceptor.accept(stream).await?;
+        let tls_stream = acceptor
+            .accept(stream)
+            .await
+            .map_err(|e| ProxyError::tls_handshake(e.to_string()))?;
         info!("TLS terminated, serving H2 with authority rewriting");
 
         let (group_id, proxy_name) = (route.group_id.clone(), route.proxy_name.clone());
@@ -52,13 +50,15 @@ impl IngressProtocolHandler for TlsHandler {
         let selected = self
             .registry
             .select_client_for_group(&group_id)
-            .ok_or_else(|| anyhow::anyhow!("no client for group: {}", group_id))?;
+            .ok_or_else(|| ProxyError::no_client_available(group_id.to_string()))?;
         let client_conn = selected.conn.clone();
         let sender_cache = tunnel_lib::new_h2_sender();
+        let metrics = ctx.metrics.clone();
 
         let service = service_fn(move |req: Request<hyper::body::Incoming>| {
             let client_conn = client_conn.clone();
             let sender_cache = sender_cache.clone();
+            let metrics = metrics.clone();
             let proxy_name = proxy_name.clone();
             let target_host = target_host.clone();
             let src_addr = src_addr.clone();
@@ -95,9 +95,15 @@ impl IngressProtocolHandler for TlsHandler {
                 {
                     Ok(resp) => Ok::<_, hyper::Error>(resp),
                     Err(e) => {
-                        tracing::error!("L7 Proxy upstream error: {}", e);
+                        let err = ProxyError::upstream_forward(e.to_string());
+                        tunnel_lib::plugin::observe_proxy_error(
+                            metrics.as_ref(),
+                            ProtocolKind::Tls.as_label(),
+                            &err,
+                        );
+                        tracing::error!(kind = ?err.kind, error = %err, "L7 Proxy upstream error");
                         Ok(Response::builder()
-                            .status(502)
+                            .status(err.http_status().unwrap_or(StatusCode::BAD_GATEWAY))
                             .body(
                                 Full::new(bytes::Bytes::from("Bad Gateway"))
                                     .map_err(|_| unreachable!())
@@ -113,7 +119,7 @@ impl IngressProtocolHandler for TlsHandler {
         H2Builder::new(hyper_util::rt::TokioExecutor::new())
             .serve_connection(io, service)
             .await
-            .map_err(|e| anyhow::anyhow!("H2 connection error: {}", e))?;
+            .map_err(|e| ProxyError::downstream_connection(format!("H2 connection error: {e}")))?;
         Ok(())
     }
 }

--- a/tunnel-lib/src/error.rs
+++ b/tunnel-lib/src/error.rs
@@ -17,10 +17,31 @@ pub enum RetryType {
     ReusedOnly,
 }
 
+impl RetryType {
+    pub fn as_label(self) -> &'static str {
+        match self {
+            RetryType::Never => "never",
+            RetryType::Safe => "safe",
+            RetryType::ReusedOnly => "reused_only",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ErrorKind {
-    QuicOpenTimeout,
-    QuicOpenConnection,
+    QuicStreamLimit,
+    QuicConnectionLost,
+    QuicConnectionFatal,
+    RoutingMissingInfo,
+    RoutingMissingHost,
+    RouteNotFound,
+    NoClientAvailable,
+    ResolveUpstream,
+    UnsupportedProtocol,
+    DownstreamConnection,
+    UpstreamConnect,
+    UpstreamForward,
+    TlsHandshake,
     HttpUpstreamRequest,
     H2cMissingAuthority,
     H2cMisdirected,
@@ -30,29 +51,120 @@ pub enum ErrorKind {
     H2cForward,
 }
 
+impl ErrorKind {
+    pub fn as_label(self) -> &'static str {
+        match self {
+            ErrorKind::QuicStreamLimit => "quic_stream_limit",
+            ErrorKind::QuicConnectionLost => "quic_connection_lost",
+            ErrorKind::QuicConnectionFatal => "quic_connection_fatal",
+            ErrorKind::RoutingMissingInfo => "routing_missing_info",
+            ErrorKind::RoutingMissingHost => "routing_missing_host",
+            ErrorKind::RouteNotFound => "route_not_found",
+            ErrorKind::NoClientAvailable => "no_client_available",
+            ErrorKind::ResolveUpstream => "resolve_upstream",
+            ErrorKind::UnsupportedProtocol => "unsupported_protocol",
+            ErrorKind::DownstreamConnection => "downstream_connection",
+            ErrorKind::UpstreamConnect => "upstream_connect",
+            ErrorKind::UpstreamForward => "upstream_forward",
+            ErrorKind::TlsHandshake => "tls_handshake",
+            ErrorKind::HttpUpstreamRequest => "http_upstream_request",
+            ErrorKind::H2cMissingAuthority => "h2c_missing_authority",
+            ErrorKind::H2cMisdirected => "h2c_misdirected",
+            ErrorKind::H2cRouteResolve => "h2c_route_resolve",
+            ErrorKind::H2cNoRoute => "h2c_no_route",
+            ErrorKind::H2cNoClient => "h2c_no_client",
+            ErrorKind::H2cForward => "h2c_forward",
+        }
+    }
+
+    pub fn source(self) -> ErrorSource {
+        match self {
+            ErrorKind::QuicStreamLimit
+            | ErrorKind::RoutingMissingInfo
+            | ErrorKind::QuicConnectionFatal
+            | ErrorKind::H2cRouteResolve => ErrorSource::Internal,
+            ErrorKind::RoutingMissingHost
+            | ErrorKind::RouteNotFound
+            | ErrorKind::UnsupportedProtocol
+            | ErrorKind::DownstreamConnection
+            | ErrorKind::TlsHandshake
+            | ErrorKind::H2cMissingAuthority
+            | ErrorKind::H2cMisdirected
+            | ErrorKind::H2cNoRoute => ErrorSource::Downstream,
+            ErrorKind::QuicConnectionLost
+            | ErrorKind::NoClientAvailable
+            | ErrorKind::ResolveUpstream
+            | ErrorKind::UpstreamConnect
+            | ErrorKind::UpstreamForward
+            | ErrorKind::HttpUpstreamRequest
+            | ErrorKind::H2cNoClient
+            | ErrorKind::H2cForward => ErrorSource::Upstream,
+        }
+    }
+
+    pub fn retry(self) -> RetryType {
+        match self {
+            ErrorKind::QuicStreamLimit
+            | ErrorKind::QuicConnectionLost
+            | ErrorKind::NoClientAvailable
+            | ErrorKind::ResolveUpstream
+            | ErrorKind::UpstreamConnect
+            | ErrorKind::UpstreamForward
+            | ErrorKind::H2cNoClient
+            | ErrorKind::H2cForward => RetryType::Safe,
+            ErrorKind::HttpUpstreamRequest => RetryType::ReusedOnly,
+            ErrorKind::QuicConnectionFatal
+            | ErrorKind::RoutingMissingInfo
+            | ErrorKind::RoutingMissingHost
+            | ErrorKind::RouteNotFound
+            | ErrorKind::UnsupportedProtocol
+            | ErrorKind::DownstreamConnection
+            | ErrorKind::TlsHandshake
+            | ErrorKind::H2cMissingAuthority
+            | ErrorKind::H2cMisdirected
+            | ErrorKind::H2cRouteResolve
+            | ErrorKind::H2cNoRoute => RetryType::Never,
+        }
+    }
+}
+
+impl ErrorSource {
+    pub fn as_label(self) -> &'static str {
+        match self {
+            ErrorSource::Upstream => "upstream",
+            ErrorSource::Downstream => "downstream",
+            ErrorSource::Internal => "internal",
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ProxyError {
     pub kind: ErrorKind,
-    pub source: ErrorSource,
-    pub retry: RetryType,
     pub detail: Option<String>,
 }
 
 impl ProxyError {
-    pub fn quic_open_timeout(timeout: Duration) -> Self {
+    pub fn quic_stream_limit(timeout: Duration) -> Self {
         Self {
-            kind: ErrorKind::QuicOpenTimeout,
-            source: ErrorSource::Internal,
-            retry: RetryType::Safe,
-            detail: Some(format!("open_bi timed out after {:?}", timeout)),
+            kind: ErrorKind::QuicStreamLimit,
+            detail: Some(format!(
+                "open_bi waited {:?} for bidirectional stream capacity",
+                timeout
+            )),
         }
     }
 
-    pub fn quic_open_connection(detail: impl Into<String>) -> Self {
+    pub fn quic_connection_lost(detail: impl Into<String>) -> Self {
         Self {
-            kind: ErrorKind::QuicOpenConnection,
-            source: ErrorSource::Internal,
-            retry: RetryType::Safe,
+            kind: ErrorKind::QuicConnectionLost,
+            detail: Some(detail.into()),
+        }
+    }
+
+    pub fn quic_connection_fatal(detail: impl Into<String>) -> Self {
+        Self {
+            kind: ErrorKind::QuicConnectionFatal,
             detail: Some(detail.into()),
         }
     }
@@ -60,17 +172,104 @@ impl ProxyError {
     pub fn http_upstream_request(detail: impl Into<String>) -> Self {
         Self {
             kind: ErrorKind::HttpUpstreamRequest,
-            source: ErrorSource::Upstream,
-            retry: RetryType::ReusedOnly,
             detail: Some(detail.into()),
         }
+    }
+
+    pub fn routing_missing_info() -> Self {
+        Self {
+            kind: ErrorKind::RoutingMissingInfo,
+            detail: None,
+        }
+    }
+
+    pub fn routing_missing_host() -> Self {
+        Self {
+            kind: ErrorKind::RoutingMissingHost,
+            detail: None,
+        }
+    }
+
+    pub fn route_not_found(detail: impl Into<String>) -> Self {
+        Self {
+            kind: ErrorKind::RouteNotFound,
+            detail: Some(detail.into()),
+        }
+    }
+
+    pub fn no_client_available(detail: impl Into<String>) -> Self {
+        Self {
+            kind: ErrorKind::NoClientAvailable,
+            detail: Some(detail.into()),
+        }
+    }
+
+    pub fn resolve_upstream(detail: impl Into<String>) -> Self {
+        Self {
+            kind: ErrorKind::ResolveUpstream,
+            detail: Some(detail.into()),
+        }
+    }
+
+    pub fn unsupported_protocol(detail: impl Into<String>) -> Self {
+        Self {
+            kind: ErrorKind::UnsupportedProtocol,
+            detail: Some(detail.into()),
+        }
+    }
+
+    pub fn downstream_connection(detail: impl Into<String>) -> Self {
+        Self {
+            kind: ErrorKind::DownstreamConnection,
+            detail: Some(detail.into()),
+        }
+    }
+
+    pub fn upstream_connect(detail: impl Into<String>) -> Self {
+        Self {
+            kind: ErrorKind::UpstreamConnect,
+            detail: Some(detail.into()),
+        }
+    }
+
+    pub fn upstream_forward(detail: impl Into<String>) -> Self {
+        Self {
+            kind: ErrorKind::UpstreamForward,
+            detail: Some(detail.into()),
+        }
+    }
+
+    pub fn tls_handshake(detail: impl Into<String>) -> Self {
+        Self {
+            kind: ErrorKind::TlsHandshake,
+            detail: Some(detail.into()),
+        }
+    }
+
+    pub fn source(&self) -> ErrorSource {
+        self.kind.source()
+    }
+
+    pub fn retry(&self) -> RetryType {
+        self.kind.retry()
+    }
+
+    pub fn should_retry(&self, was_reused: bool) -> bool {
+        match self.retry() {
+            RetryType::Never => false,
+            RetryType::Safe => true,
+            RetryType::ReusedOnly => was_reused,
+        }
+    }
+
+    pub fn with_detail(mut self, detail: impl Into<String>) -> Self {
+        self.detail = Some(detail.into());
+        self
     }
 
     pub fn h2c_missing_authority() -> Self {
         Self {
             kind: ErrorKind::H2cMissingAuthority,
-            source: ErrorSource::Downstream,
-            retry: RetryType::Never,
             detail: None,
         }
     }
@@ -78,8 +277,6 @@ impl ProxyError {
     pub fn h2c_misdirected(route_host: impl Into<String>) -> Self {
         Self {
             kind: ErrorKind::H2cMisdirected,
-            source: ErrorSource::Downstream,
-            retry: RetryType::Never,
             detail: Some(route_host.into()),
         }
     }
@@ -87,8 +284,6 @@ impl ProxyError {
     pub fn h2c_route_resolve(detail: impl Into<String>) -> Self {
         Self {
             kind: ErrorKind::H2cRouteResolve,
-            source: ErrorSource::Internal,
-            retry: RetryType::Never,
             detail: Some(detail.into()),
         }
     }
@@ -96,8 +291,6 @@ impl ProxyError {
     pub fn h2c_no_route(route_host: impl Into<String>) -> Self {
         Self {
             kind: ErrorKind::H2cNoRoute,
-            source: ErrorSource::Downstream,
-            retry: RetryType::Never,
             detail: Some(route_host.into()),
         }
     }
@@ -105,8 +298,6 @@ impl ProxyError {
     pub fn h2c_no_client(group_id: impl Into<String>) -> Self {
         Self {
             kind: ErrorKind::H2cNoClient,
-            source: ErrorSource::Upstream,
-            retry: RetryType::Safe,
             detail: Some(group_id.into()),
         }
     }
@@ -114,8 +305,6 @@ impl ProxyError {
     pub fn h2c_forward(detail: impl Into<String>) -> Self {
         Self {
             kind: ErrorKind::H2cForward,
-            source: ErrorSource::Upstream,
-            retry: RetryType::Safe,
             detail: Some(detail.into()),
         }
     }
@@ -123,13 +312,25 @@ impl ProxyError {
     pub fn http_status(&self) -> Option<StatusCode> {
         Some(match self.kind {
             ErrorKind::HttpUpstreamRequest
+            | ErrorKind::ResolveUpstream
+            | ErrorKind::UpstreamConnect
+            | ErrorKind::UpstreamForward
             | ErrorKind::H2cRouteResolve
             | ErrorKind::H2cForward => StatusCode::BAD_GATEWAY,
-            ErrorKind::H2cMissingAuthority => StatusCode::BAD_REQUEST,
+            ErrorKind::RoutingMissingInfo
+            | ErrorKind::RoutingMissingHost
+            | ErrorKind::UnsupportedProtocol
+            | ErrorKind::TlsHandshake
+            | ErrorKind::H2cMissingAuthority => StatusCode::BAD_REQUEST,
             ErrorKind::H2cMisdirected => StatusCode::MISDIRECTED_REQUEST,
-            ErrorKind::H2cNoRoute => StatusCode::NOT_FOUND,
-            ErrorKind::H2cNoClient => StatusCode::SERVICE_UNAVAILABLE,
-            ErrorKind::QuicOpenTimeout | ErrorKind::QuicOpenConnection => return None,
+            ErrorKind::RouteNotFound | ErrorKind::H2cNoRoute => StatusCode::NOT_FOUND,
+            ErrorKind::NoClientAvailable | ErrorKind::H2cNoClient => {
+                StatusCode::SERVICE_UNAVAILABLE
+            }
+            ErrorKind::DownstreamConnection => return None,
+            ErrorKind::QuicStreamLimit
+            | ErrorKind::QuicConnectionLost
+            | ErrorKind::QuicConnectionFatal => return None,
         })
     }
 }
@@ -137,8 +338,19 @@ impl ProxyError {
 impl fmt::Display for ProxyError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let label = match self.kind {
-            ErrorKind::QuicOpenTimeout => "quic open timeout",
-            ErrorKind::QuicOpenConnection => "quic open connection error",
+            ErrorKind::QuicStreamLimit => "quic stream limit",
+            ErrorKind::QuicConnectionLost => "quic connection lost",
+            ErrorKind::QuicConnectionFatal => "quic connection fatal",
+            ErrorKind::RoutingMissingInfo => "routing info missing",
+            ErrorKind::RoutingMissingHost => "routing host missing",
+            ErrorKind::RouteNotFound => "route not found",
+            ErrorKind::NoClientAvailable => "no client available",
+            ErrorKind::ResolveUpstream => "upstream resolve failed",
+            ErrorKind::UnsupportedProtocol => "unsupported protocol",
+            ErrorKind::DownstreamConnection => "downstream connection failed",
+            ErrorKind::UpstreamConnect => "upstream connect failed",
+            ErrorKind::UpstreamForward => "upstream forward failed",
+            ErrorKind::TlsHandshake => "tls handshake failed",
             ErrorKind::HttpUpstreamRequest => "http upstream request failed",
             ErrorKind::H2cMissingAuthority => "h2c missing authority",
             ErrorKind::H2cMisdirected => "h2c misdirected request",
@@ -155,3 +367,32 @@ impl fmt::Display for ProxyError {
 }
 
 impl StdError for ProxyError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proxy_error_labels_are_stable_for_metrics() {
+        let err = ProxyError::quic_stream_limit(Duration::from_millis(10));
+
+        assert_eq!(err.kind.as_label(), "quic_stream_limit");
+        assert_eq!(err.source().as_label(), "internal");
+        assert_eq!(err.retry().as_label(), "safe");
+    }
+
+    #[test]
+    fn retry_policy_honors_reused_only() {
+        let err = ProxyError::http_upstream_request("idle close");
+
+        assert!(!err.should_retry(false));
+        assert!(err.should_retry(true));
+    }
+
+    #[test]
+    fn http_status_maps_client_availability_to_503() {
+        let err = ProxyError::no_client_available("group-a");
+
+        assert_eq!(err.http_status(), Some(StatusCode::SERVICE_UNAVAILABLE));
+    }
+}

--- a/tunnel-lib/src/open_bi.rs
+++ b/tunnel-lib/src/open_bi.rs
@@ -1,13 +1,14 @@
-use crate::inflight::{begin_inflight, InflightCounter, InflightGuard};
 use crate::error::ProxyError;
+use crate::inflight::{InflightCounter, InflightGuard, begin_inflight};
 use quinn::{Connection, RecvStream, SendStream};
 use std::time::{Duration, Instant};
 
 #[derive(Debug)]
 pub enum OpenBiOutcome {
     Ok,
-    Timeout,
-    ConnectionError,
+    StreamLimit,
+    ConnectionLost,
+    ConnectionFatal,
 }
 
 pub struct OpenedStream {
@@ -54,12 +55,34 @@ where
             })
         }
         Ok(Err(e)) => {
-            on_wait_done(elapsed, OpenBiOutcome::ConnectionError);
-            Err(ProxyError::quic_open_connection(e.to_string()))
+            let (outcome, err) = classify_open_bi_error(e);
+            on_wait_done(elapsed, outcome);
+            Err(err)
         }
         Err(_) => {
-            on_wait_done(elapsed, OpenBiOutcome::Timeout);
-            Err(ProxyError::quic_open_timeout(stream_timeout))
+            on_wait_done(elapsed, OpenBiOutcome::StreamLimit);
+            Err(ProxyError::quic_stream_limit(stream_timeout))
         }
+    }
+}
+
+fn classify_open_bi_error(error: quinn::ConnectionError) -> (OpenBiOutcome, ProxyError) {
+    use quinn::ConnectionError;
+
+    match error {
+        ConnectionError::TimedOut
+        | ConnectionError::Reset
+        | ConnectionError::ConnectionClosed(_)
+        | ConnectionError::ApplicationClosed(_) => (
+            OpenBiOutcome::ConnectionLost,
+            ProxyError::quic_connection_lost(error.to_string()),
+        ),
+        ConnectionError::VersionMismatch
+        | ConnectionError::TransportError(_)
+        | ConnectionError::LocallyClosed
+        | ConnectionError::CidsExhausted => (
+            OpenBiOutcome::ConnectionFatal,
+            ProxyError::quic_connection_fatal(error.to_string()),
+        ),
     }
 }

--- a/tunnel-lib/src/plugin/dispatcher.rs
+++ b/tunnel-lib/src/plugin/dispatcher.rs
@@ -1,14 +1,16 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::net::TcpStream;
 use tracing::error;
 
-use super::ctx::{AdmissionReq, PhaseOutcome, PhaseTiming, PhaseResult, RouteCtx, ServerCtx};
+use super::ctx::{AdmissionReq, PhaseOutcome, PhaseResult, PhaseTiming, RouteCtx, ServerCtx};
 use super::ingress::{ProtocolHint, ProtocolKind};
+use super::metrics::observe_proxy_error;
 use super::registry::PluginRegistry;
 use super::service::TunnelService;
+use crate::ProxyError;
 use crate::protocol::detect::{detect_protocol_and_host, extract_tls_sni};
 use crate::proxy::core::Protocol;
 
@@ -92,7 +94,10 @@ pub struct IngressDispatcher {
 
 impl IngressDispatcher {
     pub fn new(registry: Arc<PluginRegistry>, listener_port: u16) -> Self {
-        Self { registry, listener_port }
+        Self {
+            registry,
+            listener_port,
+        }
     }
 
     pub async fn dispatch(
@@ -129,7 +134,10 @@ impl IngressDispatcher {
                         )),
                     };
                     safe_logging(svc, ctx, &outcome);
-                    return Err(anyhow!("connection rejected at pre_admission (status={})", status));
+                    return Err(anyhow!(
+                        "connection rejected at pre_admission (status={})",
+                        status
+                    ));
                 }
                 PhaseResult::Continue(()) => {}
             }
@@ -150,7 +158,10 @@ impl IngressDispatcher {
                     )),
                 };
                 safe_logging(svc, ctx, &outcome);
-                return Err(anyhow!("connection rejected at admission (status={})", status));
+                return Err(anyhow!(
+                    "connection rejected at admission (status={})",
+                    status
+                ));
             }
             PhaseResult::Continue(()) => {
                 ctx.admitted = true;
@@ -202,6 +213,11 @@ impl IngressDispatcher {
         ctx.timing = timing.clone();
 
         let handle_result = handler.handle(stream, route, ctx).await;
+        if let Err(err) = &handle_result {
+            if let Some(proxy_error) = err.downcast_ref::<ProxyError>() {
+                observe_proxy_error(ctx.metrics.as_ref(), hint.kind.as_label(), proxy_error);
+            }
+        }
 
         // ── Phase 6: logging ──────────────────────────────────────────────────
         timing.completed_at = Some(Instant::now());

--- a/tunnel-lib/src/plugin/ingress.rs
+++ b/tunnel-lib/src/plugin/ingress.rs
@@ -3,8 +3,8 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use tokio::net::TcpStream;
 
-use crate::proxy::core::Protocol;
 use super::ctx::{Route, ServerCtx};
+use crate::proxy::core::Protocol;
 
 // ── ProtocolKind ─────────────────────────────────────────────────────────────
 
@@ -18,6 +18,17 @@ pub enum ProtocolKind {
     H2c,   // HTTP/2 cleartext preface
     Http1, // HTTP/1.x or WebSocket upgrade
     Tcp,   // Unrecognised — passthrough
+}
+
+impl ProtocolKind {
+    pub fn as_label(self) -> &'static str {
+        match self {
+            ProtocolKind::Tls => "tls",
+            ProtocolKind::H2c => "h2c",
+            ProtocolKind::Http1 => "h1",
+            ProtocolKind::Tcp => "tcp",
+        }
+    }
 }
 
 // ── ProtocolHint ─────────────────────────────────────────────────────────────
@@ -95,10 +106,5 @@ pub trait IngressProtocolHandler: Send + Sync + 'static {
     /// single connection).
     /// `ctx.hint.raw_preface` contains the bytes that were peeked; the handler
     /// is responsible for prepending them when forwarding to the upstream.
-    async fn handle(
-        &self,
-        stream: TcpStream,
-        route: Option<Route>,
-        ctx: &ServerCtx,
-    ) -> Result<()>;
+    async fn handle(&self, stream: TcpStream, route: Option<Route>, ctx: &ServerCtx) -> Result<()>;
 }

--- a/tunnel-lib/src/plugin/metrics.rs
+++ b/tunnel-lib/src/plugin/metrics.rs
@@ -1,3 +1,5 @@
+use crate::ProxyError;
+
 /// Abstraction over metrics backends.
 ///
 /// Injected into `ServerCtx` and `EgressCtx`; handlers call `ctx.metrics.incr()`
@@ -19,4 +21,16 @@ impl MetricsSink for NoopSink {
     fn incr(&self, _name: &'static str, _labels: &[(&'static str, &str)]) {}
     #[inline]
     fn observe(&self, _name: &'static str, _value: f64, _labels: &[(&'static str, &str)]) {}
+}
+
+pub fn observe_proxy_error(metrics: &dyn MetricsSink, protocol: &str, err: &ProxyError) {
+    metrics.incr(
+        "duotunnel_proxy_errors_total",
+        &[
+            ("protocol", protocol),
+            ("type", err.kind.as_label()),
+            ("source", err.source().as_label()),
+            ("retry", err.retry().as_label()),
+        ],
+    );
 }

--- a/tunnel-lib/src/plugin/mod.rs
+++ b/tunnel-lib/src/plugin/mod.rs
@@ -35,7 +35,7 @@ pub use ctx::{
 pub use dispatcher::{IngressDispatcher, SNIFF_LIMIT};
 pub use egress::{Connected, LoadBalancer, Resolver, SystemResolver, UpstreamDialer};
 pub use ingress::{IngressProtocolHandler, ProtocolHint, ProtocolKind};
-pub use metrics::{MetricsSink, NoopSink};
+pub use metrics::{MetricsSink, NoopSink, observe_proxy_error};
 pub use module::ConnectionModule;
 pub use registry::PluginRegistry;
 pub use route::{NoRouteResolver, RouteResolver};

--- a/tunnel-lib/src/proxy/core.rs
+++ b/tunnel-lib/src/proxy/core.rs
@@ -1,4 +1,5 @@
 use super::peers::PeerSpec;
+use crate::ProxyError;
 use crate::infra::peek_buf::PeekBufPool;
 use crate::models::msg::RoutingInfo;
 use anyhow::Result;
@@ -6,9 +7,7 @@ use bytes::Bytes;
 use quinn::{RecvStream, SendStream};
 use std::net::SocketAddr;
 use std::sync::OnceLock;
-#[derive(
-    Debug, Clone, Copy, PartialEq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)]
 pub enum Protocol {
     H1,
     H2,
@@ -26,7 +25,7 @@ pub trait UpstreamResolver: Send + Sync {
     fn upstream_peer(
         &self,
         context: &mut Context,
-    ) -> impl std::future::Future<Output = Result<PeerSpec>> + Send;
+    ) -> impl std::future::Future<Output = std::result::Result<PeerSpec, ProxyError>> + Send;
 
     fn connect_peer(
         &self,
@@ -34,7 +33,7 @@ pub trait UpstreamResolver: Send + Sync {
         send: SendStream,
         recv: RecvStream,
         initial_data: Option<Bytes>,
-    ) -> impl std::future::Future<Output = Result<()>> + Send;
+    ) -> impl std::future::Future<Output = std::result::Result<(), ProxyError>> + Send;
 }
 pub struct ProxyEngine<A: UpstreamResolver> {
     app: A,
@@ -77,7 +76,9 @@ impl<A: UpstreamResolver> ProxyEngine<A> {
             routing_info,
         };
         let peer = self.app.upstream_peer(&mut ctx).await?;
-        self.app.connect_peer(peer, send, recv, ctx.initial_bytes).await?;
+        self.app
+            .connect_peer(peer, send, recv, ctx.initial_bytes)
+            .await?;
         Ok(())
     }
 }

--- a/tunnel-lib/src/proxy/h2.rs
+++ b/tunnel-lib/src/proxy/h2.rs
@@ -1,7 +1,7 @@
 use super::http_connector::SharedHttpConnector;
 use super::peers::HttpPeerSpec;
-use crate::transport::quinn_io::{PrefixedReadWrite, QuinnStream};
 use crate::ProxyError;
+use crate::transport::quinn_io::{PrefixedReadWrite, QuinnStream};
 use anyhow::Result;
 use bytes::Bytes;
 use http_body_util::BodyExt;
@@ -45,19 +45,21 @@ where
             let boxed_body = body.map_err(std::io::Error::other).boxed();
             let upstream_req = Request::from_parts(parts, boxed_body);
             match connector.request(&spec, upstream_req).await {
-                Ok(resp) => {
-                    Ok::<_, hyper::Error>(resp)
-                }
+                Ok(resp) => Ok::<_, hyper::Error>(resp),
                 Err(e) => {
                     let proxy_err = ProxyError::http_upstream_request(e.to_string());
                     debug!(
                         kind = ?proxy_err.kind,
-                        retry = ?proxy_err.retry,
+                        retry = ?proxy_err.retry(),
                         error = %proxy_err,
                         "H2 forward: upstream request failed"
                     );
                     Ok(Response::builder()
-                        .status(proxy_err.http_status().unwrap_or(hyper::StatusCode::BAD_GATEWAY))
+                        .status(
+                            proxy_err
+                                .http_status()
+                                .unwrap_or(hyper::StatusCode::BAD_GATEWAY),
+                        )
                         .body(
                             http_body_util::Full::new(Bytes::from("Bad Gateway"))
                                 .map_err(|never| match never {})

--- a/tunnel-lib/src/proxy/http.rs
+++ b/tunnel-lib/src/proxy/http.rs
@@ -1,8 +1,8 @@
 use super::http_connector::SharedHttpConnector;
 use super::peers::HttpPeerSpec;
-use crate::protocol::driver::h1::Http1Driver;
-use crate::protocol::driver::ProtocolDriver;
 use crate::ProxyError;
+use crate::protocol::driver::ProtocolDriver;
+use crate::protocol::driver::h1::Http1Driver;
 use anyhow::Result;
 use bytes::Bytes;
 use hyper::Request;
@@ -77,22 +77,21 @@ impl HttpPeer {
             initial_data,
         );
         loop {
-            let req =
-                match lazy_timeout(KEEPALIVE_IDLE_TIMEOUT, driver.read_request()).await {
-                    Ok(Ok(Some(r))) => r,
-                    Ok(Ok(None)) => {
-                        debug!(upstream = %upstream, "H1 keep-alive: clean EOF, closing");
-                        break;
-                    }
-                    Ok(Err(e)) => {
-                        debug!(upstream = %upstream, error = %e, "H1 keep-alive: read_request error, closing");
-                        break;
-                    }
-                    Err(()) => {
-                        debug!(upstream = %upstream, "H1 keep-alive: idle timeout, closing");
-                        break;
-                    }
-                };
+            let req = match lazy_timeout(KEEPALIVE_IDLE_TIMEOUT, driver.read_request()).await {
+                Ok(Ok(Some(r))) => r,
+                Ok(Ok(None)) => {
+                    debug!(upstream = %upstream, "H1 keep-alive: clean EOF, closing");
+                    break;
+                }
+                Ok(Err(e)) => {
+                    debug!(upstream = %upstream, error = %e, "H1 keep-alive: read_request error, closing");
+                    break;
+                }
+                Err(()) => {
+                    debug!(upstream = %upstream, "H1 keep-alive: idle timeout, closing");
+                    break;
+                }
+            };
             let should_close_after = driver.should_close;
             let mut builder = Request::builder()
                 .method(req.method)
@@ -113,7 +112,7 @@ impl HttpPeer {
                     debug!(
                         upstream = %self.spec.target_host,
                         kind = ?proxy_err.kind,
-                        retry = ?proxy_err.retry,
+                        retry = ?proxy_err.retry(),
                         error = %proxy_err,
                         "H1 upstream request failed, sending 502"
                     );


### PR DESCRIPTION
## Summary
- Replace hot-path `anyhow` boundaries with structured `ProxyError` classifications.
- Split QUIC open failures into stream capacity, transient connection loss, and fatal connection errors for retry/eviction behavior.
- Add shared proxy error metrics labels for protocol, type, source, and retry policy.

## Test plan
- [ ] Not run (not requested).