### PR TITLE
🧪 [testing improvement] Add unit tests for `build_client_config_for_group`

### DIFF
--- a/server/config.rs
+++ b/server/config.rs
@@ -339,3 +339,95 @@ pub fn build_client_config_for_group(
         upstreams,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_build_client_config_for_group_not_found() {
+        let tm = TunnelManagement {
+            server_ingress_routing: Default::default(),
+            client_configs: ClientConfigs {
+                groups: HashMap::new(),
+            },
+        };
+        assert!(build_client_config_for_group(&tm, "nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_build_client_config_for_group_empty() {
+        let mut groups = HashMap::new();
+        groups.insert(
+            "group1".to_string(),
+            GroupConfig {
+                config_version: "v1".to_string(),
+                upstreams: HashMap::new(),
+            },
+        );
+        let tm = TunnelManagement {
+            server_ingress_routing: Default::default(),
+            client_configs: ClientConfigs { groups },
+        };
+
+        let config = build_client_config_for_group(&tm, "group1").expect("group1 should exist");
+        assert_eq!(config.config_version, "v1");
+        assert!(config.upstreams.is_empty());
+    }
+
+    #[test]
+    fn test_build_client_config_for_group_success() {
+        let mut upstreams = HashMap::new();
+        upstreams.insert(
+            "upstream1".to_string(),
+            UpstreamDef {
+                servers: vec![
+                    ServerDef {
+                        address: "127.0.0.1:8080".to_string(),
+                        resolve: false,
+                    },
+                    ServerDef {
+                        address: "example.com:80".to_string(),
+                        resolve: true,
+                    },
+                ],
+                lb_policy: "round_robin".to_string(),
+            },
+        );
+
+        let mut groups = HashMap::new();
+        groups.insert(
+            "group_prod".to_string(),
+            GroupConfig {
+                config_version: "v2".to_string(),
+                upstreams,
+            },
+        );
+
+        let tm = TunnelManagement {
+            server_ingress_routing: Default::default(),
+            client_configs: ClientConfigs { groups },
+        };
+
+        let config =
+            build_client_config_for_group(&tm, "group_prod").expect("group_prod should exist");
+        assert_eq!(config.config_version, "v2");
+        assert_eq!(config.upstreams.len(), 1);
+
+        let upstream = config
+            .upstreams
+            .iter()
+            .find(|u| u.name == "upstream1")
+            .expect("upstream1 missing");
+
+        assert_eq!(upstream.lb_policy, "round_robin");
+        assert_eq!(upstream.servers.len(), 2);
+
+        assert_eq!(upstream.servers[0].address, "127.0.0.1:8080");
+        assert_eq!(upstream.servers[0].resolve, false);
+
+        assert_eq!(upstream.servers[1].address, "example.com:80");
+        assert_eq!(upstream.servers[1].resolve, true);
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap in `server/config.rs` where `build_client_config_for_group` was not tested has been addressed.
📊 **Coverage:** Three scenarios are now tested: non-existent group IDs, valid groups with zero upstreams configured, and fully populated groups asserting mapping correctness for server addresses, load balancer policies, etc.
✨ **Result:** The improvement in test coverage increases confidence during config refactoring, ensuring valid mappings are produced safely.

---
*PR created automatically by Jules for task [9487866735934289046](https://jules.google.com/task/9487866735934289046) started by @locustbaby*