### PR TITLE
⚡ perf: use async file I/O for loading TLS certificates during client initialization

### DIFF
--- a/client/config.rs
+++ b/client/config.rs
@@ -308,7 +308,10 @@ impl ClientConfigFile {
                 self.overload.inflight_yield_threshold, self.overload.inflight_sleep_threshold
             ));
         }
-        if let (Some(ypct), Some(spct)) = (self.overload.inflight_yield_pct, self.overload.inflight_sleep_pct) {
+        if let (Some(ypct), Some(spct)) = (
+            self.overload.inflight_yield_pct,
+            self.overload.inflight_sleep_pct,
+        ) {
             if ypct > spct {
                 errors.push(format!(
                     "overload.inflight_yield_pct ({}) must be <= inflight_sleep_pct ({})",

--- a/client/ingress/handler.rs
+++ b/client/ingress/handler.rs
@@ -19,7 +19,9 @@ pub async fn handle_work_stream(
         src = format!("{}:{}", routing_info.src_addr, routing_info.src_port),
         "received work stream"
     );
-    let ip = routing_info.src_addr.parse::<std::net::IpAddr>()
+    let ip = routing_info
+        .src_addr
+        .parse::<std::net::IpAddr>()
         .unwrap_or(std::net::IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED));
     let client_addr = std::net::SocketAddr::new(ip, routing_info.src_port);
     let app = ClientApp::new(proxy_map, tcp_params);

--- a/client/main.rs
+++ b/client/main.rs
@@ -6,8 +6,8 @@
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 use anyhow::{anyhow, Result};
-use rustls::pki_types::pem::PemObject;
 use clap::Parser;
+use rustls::pki_types::pem::PemObject;
 use std::collections::HashSet;
 use std::future::Future;
 use std::net::{IpAddr, SocketAddr};
@@ -119,7 +119,7 @@ async fn async_main() -> Result<()> {
     tunnel_lib::infra::observability::init_tracing(log_level);
     info!("Starting DuoTunnel Client");
     info!(server = % config.server_address(), "Configuration loaded");
-    let endpoint = build_quic_endpoint(&config)?;
+    let endpoint = build_quic_endpoint(&config).await?;
     let cancel = CancellationToken::new();
     let cancel_clone = cancel.clone();
     crate::spawn_task(async move {
@@ -132,7 +132,8 @@ async fn async_main() -> Result<()> {
     if let Some(port) = config.metrics_port {
         crate::spawn_task(run_healthz_server(port, ready.clone()));
     }
-    let entry_pool = EntryConnPool::new(config.quic.max_concurrent_streams, config.quic.connections);
+    let entry_pool =
+        EntryConnPool::new(config.quic.max_concurrent_streams, config.quic.connections);
     let mut engine = ClientEngine::new(cancel.clone());
 
     if let Some(entry_port) = config.entry.port {
@@ -231,8 +232,8 @@ fn run_with_dial9(trace_path: PathBuf, fut: impl Future<Output = Result<()>>) ->
     }
     result
 }
-fn build_quic_endpoint(config: &ClientConfigFile) -> Result<quinn::Endpoint> {
-    let mut crypto = build_tls_config(config)?;
+async fn build_quic_endpoint(config: &ClientConfigFile) -> Result<quinn::Endpoint> {
+    let mut crypto = build_tls_config(config).await?;
     crypto.alpn_protocols = vec![b"tunnel-quic".to_vec()];
     let mut client_config = quinn::ClientConfig::new(Arc::new(
         quinn::crypto::rustls::QuicClientConfig::try_from(crypto)?,
@@ -427,7 +428,7 @@ async fn resolve_server_addresses(
     }
     Ok(addrs)
 }
-fn build_tls_config(config: &ClientConfigFile) -> Result<rustls::ClientConfig> {
+async fn build_tls_config(config: &ClientConfigFile) -> Result<rustls::ClientConfig> {
     if config.tls_skip_verify {
         warn!("TLS certificate verification is DISABLED - this is insecure!");
         return Ok(rustls::ClientConfig::builder()
@@ -437,9 +438,10 @@ fn build_tls_config(config: &ClientConfigFile) -> Result<rustls::ClientConfig> {
     }
     let mut root_store = rustls::RootCertStore::empty();
     if let Some(ca_path) = &config.tls_ca_cert {
-        let ca_file = std::fs::File::open(ca_path)
-            .map_err(|e| anyhow::anyhow!("Failed to open CA cert file {}: {}", ca_path, e))?;
-        let mut reader = std::io::BufReader::new(ca_file);
+        let ca_file_bytes = tokio::fs::read(ca_path)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to read CA cert file {}: {}", ca_path, e))?;
+        let mut reader = std::io::BufReader::new(std::io::Cursor::new(ca_file_bytes));
         let certs = rustls::pki_types::CertificateDer::pem_reader_iter(&mut reader)
             .filter_map(|r| r.ok())
             .collect::<Vec<_>>();

--- a/client/tunnel/conn_pool.rs
+++ b/client/tunnel/conn_pool.rs
@@ -2,7 +2,9 @@ use arc_swap::ArcSwap;
 use quinn::Connection;
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
-use tunnel_lib::{inflight_load, new_inflight_table, pick_p2c_inflight, InflightSlotId, InflightTable};
+use tunnel_lib::{
+    inflight_load, new_inflight_table, pick_p2c_inflight, InflightSlotId, InflightTable,
+};
 
 pub struct PooledConnection {
     pub conn: Connection,
@@ -41,10 +43,7 @@ impl EntryConnPool {
             return;
         }
         let Some(slot_id) = self.inflight_table.alloc_slot() else {
-            tracing::error!(
-                conn_id = stable_id,
-                "Inflight slot table exhausted"
-            );
+            tracing::error!(conn_id = stable_id, "Inflight slot table exhausted");
             g.ids.remove(&stable_id);
             return;
         };
@@ -75,7 +74,13 @@ impl EntryConnPool {
             32,
             3,
             |c| c.conn.close_reason().is_none() && !excluded.contains(&c.conn.stable_id()),
-            |c| inflight_load(&c.inflight_table, c.slot_id, std::sync::atomic::Ordering::Relaxed),
+            |c| {
+                inflight_load(
+                    &c.inflight_table,
+                    c.slot_id,
+                    std::sync::atomic::Ordering::Relaxed,
+                )
+            },
         )
         .cloned()
     }

--- a/client/tunnel/supervisor.rs
+++ b/client/tunnel/supervisor.rs
@@ -127,7 +127,10 @@ fn random_delay_up_to(cap: Duration) -> Duration {
 }
 pub fn classify_login_failure(resp_error: Option<&str>) -> ConnectError {
     let msg = resp_error.unwrap_or("unknown login error");
-    if msg.contains("timeout") || msg.contains("unexpected message type") || msg.contains("registration failed") {
+    if msg.contains("timeout")
+        || msg.contains("unexpected message type")
+        || msg.contains("registration failed")
+    {
         ConnectError::transient(anyhow!("login rejected by server: {}", msg))
     } else {
         ConnectError::fatal(anyhow!("login rejected by server: {}", msg))


### PR DESCRIPTION
💡 **What:** Refactored the `build_tls_config` and `build_quic_endpoint` functions to be `async fn` and replaced `std::fs::File::open` with `tokio::fs::read`.
🎯 **Why:** The prior code was executing synchronous File I/O (`std::fs::File::open`) from inside an asynchronous execution context. This blocks the underlying Tokio worker thread, which can degrade initialization performance and cause thread starvation.
📊 **Measured Improvement:** No specific benchmark tool exists for this client startup configuration loading path since it only executes exactly once when the application starts (`async_main`). However, changing synchronous disk I/O in Tokio contexts to asynchronous alternatives is a universally recommended practice for the Tokio runtime to avoid blocking worker threads, strictly making it a performance improvement by preventing starvation.

---
*PR created automatically by Jules for task [17030707177319359962](https://jules.google.com/task/17030707177319359962) started by @locustbaby*