### PR TITLE
🔒 Fix UB from uninitialized memory reference in msg.rs

### DIFF
--- a/tunnel-lib/src/models/msg.rs
+++ b/tunnel-lib/src/models/msg.rs
@@ -128,9 +128,7 @@ where
         return Err(anyhow!("Message too large: {} bytes", len));
     }
     let mut buf = AlignedVec::<16>::with_capacity(len);
-    unsafe {
-        buf.set_len(len);
-    }
+    buf.resize(len, 0);
     reader.read_exact(&mut buf[..]).await?;
     let archived = rkyv::access::<M::Archived, rancor::Error>(&buf[..])
         .map_err(|e| anyhow!("rkyv access failed: {e}"))?;


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Undefined Behavior (UB) caused by creating a slice of uninitialized memory in Rust. 

⚠️ **Risk:** The potential impact if left unfixed
By extending an `AlignedVec` via `unsafe { set_len }` and immediately taking a `&mut buf[..]` slice, the code violated Rust's aliasing and memory initialization guarantees. Depending on compiler optimizations, this could lead to memory corruption, unexpected crashes, or potentially exposure of stale memory contents to the networking layer.

🛡️ **Solution:** How the fix addresses the vulnerability
Replaced the `unsafe` block with a safe `.resize(len, 0)` call. This explicitly zero-initializes the newly allocated memory up to the desired length, making it safe to slice and pass into `read_exact`.

---
*PR created automatically by Jules for task [9309142854574366937](https://jules.google.com/task/9309142854574366937) started by @locustbaby*