### PR TITLE
🧪 [testing improvement] Add unit tests for routing_data_from_server_config

### DIFF
--- a/tunnel-store/src/rules.rs
+++ b/tunnel-store/src/rules.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
 use async_trait::async_trait;
 pub use tunnel_lib::{
-    ClientGroupDef as ClientGroup, ClientUpstreamDef as ClientUpstream,
-    EgressUpstreamDef, EgressVhostRuleDef as EgressVhostRule,
-    IngressListenerDef as IngressListener, IngressListenerModeDef as IngressListenerMode,
-    IngressVhostRuleDef as IngressVhostRule, UpstreamServerDef as UpstreamServer,
+    ClientGroupDef as ClientGroup, ClientUpstreamDef as ClientUpstream, EgressUpstreamDef,
+    EgressVhostRuleDef as EgressVhostRule, IngressListenerDef as IngressListener,
+    IngressListenerModeDef as IngressListenerMode, IngressVhostRuleDef as IngressVhostRule,
+    UpstreamServerDef as UpstreamServer,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/tunnel-store/src/server_config.rs
+++ b/tunnel-store/src/server_config.rs
@@ -294,13 +294,18 @@ impl ServerConfigFile {
         if self.server.open_stream_timeout_ms == 0 {
             errors.push("server.open_stream_timeout_ms must be >= 1".into());
         }
-        if self.server.overload.inflight_yield_threshold > self.server.overload.inflight_sleep_threshold {
+        if self.server.overload.inflight_yield_threshold
+            > self.server.overload.inflight_sleep_threshold
+        {
             errors.push(format!(
                 "server.overload.inflight_yield_threshold ({}) must be <= inflight_sleep_threshold ({})",
                 self.server.overload.inflight_yield_threshold, self.server.overload.inflight_sleep_threshold
             ));
         }
-        if let (Some(ypct), Some(spct)) = (self.server.overload.inflight_yield_pct, self.server.overload.inflight_sleep_pct) {
+        if let (Some(ypct), Some(spct)) = (
+            self.server.overload.inflight_yield_pct,
+            self.server.overload.inflight_sleep_pct,
+        ) {
             if ypct > spct {
                 errors.push(format!(
                     "server.overload.inflight_yield_pct ({}) must be <= inflight_sleep_pct ({})",
@@ -412,5 +417,204 @@ pub fn routing_data_from_server_config(cfg: &ServerConfigFile) -> RoutingData {
         client_groups,
         egress_upstreams,
         egress_vhost_rules,
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_routing_data_from_server_config_empty() {
+        // Create an empty ServerConfigFile using default values for everything
+        // Note: ServerConfigFile doesn't have a Default implementation, so we build it.
+        let cfg = ServerConfigFile {
+            server: ServerBasicConfig {
+                tunnel_port: 8080,
+                log_level: None,
+                trace_enabled: false,
+                database_url: "".to_string(),
+                metrics_port: None,
+                quic: Default::default(),
+                tcp: Default::default(),
+                http_pool: Default::default(),
+                proxy_buffers: Default::default(),
+                pki: Default::default(),
+                login_timeout_secs: 10,
+                open_stream_timeout_ms: 5000,
+                h2_single_authority: true,
+                accept_workers: None,
+                overload: Default::default(),
+            },
+            server_egress_upstream: Default::default(),
+            tunnel_management: Default::default(),
+        };
+
+        let routing_data = routing_data_from_server_config(&cfg);
+
+        assert!(routing_data.ingress_listeners.is_empty());
+        assert!(routing_data.client_groups.is_empty());
+        assert!(routing_data.egress_upstreams.is_empty());
+        assert!(routing_data.egress_vhost_rules.is_empty());
+    }
+
+    #[test]
+    fn test_routing_data_from_server_config_populated() {
+        let mut client_upstreams = HashMap::new();
+        client_upstreams.insert(
+            "client_up_1".to_string(),
+            UpstreamDef {
+                servers: vec![ServerDef {
+                    address: "10.0.0.1:80".to_string(),
+                    resolve: true,
+                }],
+                lb_policy: "round_robin".to_string(),
+            },
+        );
+
+        let mut groups = HashMap::new();
+        groups.insert(
+            "group_a".to_string(),
+            GroupConfig {
+                config_version: "v1".to_string(),
+                upstreams: client_upstreams,
+            },
+        );
+
+        let mut egress_upstreams = HashMap::new();
+        egress_upstreams.insert(
+            "egress_up_1".to_string(),
+            UpstreamDef {
+                servers: vec![ServerDef {
+                    address: "20.0.0.1:443".to_string(),
+                    resolve: false,
+                }],
+                lb_policy: "least_conn".to_string(),
+            },
+        );
+
+        let cfg = ServerConfigFile {
+            server: ServerBasicConfig {
+                tunnel_port: 8080,
+                log_level: None,
+                trace_enabled: false,
+                database_url: "".to_string(),
+                metrics_port: None,
+                quic: Default::default(),
+                tcp: Default::default(),
+                http_pool: Default::default(),
+                proxy_buffers: Default::default(),
+                pki: Default::default(),
+                login_timeout_secs: 10,
+                open_stream_timeout_ms: 5000,
+                h2_single_authority: true,
+                accept_workers: None,
+                overload: Default::default(),
+            },
+            server_egress_upstream: ServerEgressUpstream {
+                upstreams: egress_upstreams,
+                rules: EgressRules {
+                    vhost: vec![EgressHttpRule {
+                        match_host: "example.com".to_string(),
+                        action_upstream: "egress_up_1".to_string(),
+                    }],
+                },
+            },
+            tunnel_management: TunnelManagement {
+                server_ingress_routing: IngressRouting {
+                    listeners: vec![
+                        IngressListenerDef {
+                            port: 80,
+                            mode: IngressModeDef::Http(HttpListenerDef {
+                                vhost: vec![VhostRuleDef {
+                                    match_host: "test.local".to_string(),
+                                    client_group: "group_a".to_string(),
+                                    proxy_name: "proxy_1".to_string(),
+                                }],
+                            }),
+                        },
+                        IngressListenerDef {
+                            port: 443,
+                            mode: IngressModeDef::Tcp(TcpListenerDef {
+                                client_group: "group_b".to_string(),
+                                proxy_name: "proxy_2".to_string(),
+                            }),
+                        },
+                    ],
+                },
+                client_configs: ClientConfigs { groups },
+            },
+        };
+
+        let routing_data = routing_data_from_server_config(&cfg);
+
+        // Assert Ingress Listeners
+        assert_eq!(routing_data.ingress_listeners.len(), 2);
+
+        let http_listener = routing_data
+            .ingress_listeners
+            .iter()
+            .find(|l| l.port == 80)
+            .unwrap();
+        assert_eq!(
+            http_listener.id, 0,
+            "IngressListener ID should be initialized to 0 for DB auto-assignment"
+        );
+        if let IngressListenerMode::Http { vhost } = &http_listener.mode {
+            assert_eq!(vhost.len(), 1);
+            assert_eq!(vhost[0].match_host, "test.local");
+            assert_eq!(vhost[0].group_id, "group_a");
+            assert_eq!(vhost[0].proxy_name, "proxy_1");
+        } else {
+            panic!("Expected Http mode");
+        }
+
+        let tcp_listener = routing_data
+            .ingress_listeners
+            .iter()
+            .find(|l| l.port == 443)
+            .unwrap();
+        assert_eq!(
+            tcp_listener.id, 0,
+            "IngressListener ID should be initialized to 0 for DB auto-assignment"
+        );
+        if let IngressListenerMode::Tcp {
+            group_id,
+            proxy_name,
+        } = &tcp_listener.mode
+        {
+            assert_eq!(group_id, "group_b");
+            assert_eq!(proxy_name, "proxy_2");
+        } else {
+            panic!("Expected Tcp mode");
+        }
+
+        // Assert Client Groups
+        assert_eq!(routing_data.client_groups.len(), 1);
+        let group = &routing_data.client_groups[0];
+        assert_eq!(group.group_id, "group_a");
+        assert_eq!(group.config_version, "v1");
+        assert_eq!(group.upstreams.len(), 1);
+        let up = &group.upstreams[0];
+        assert_eq!(up.name, "client_up_1");
+        assert_eq!(up.lb_policy, "round_robin");
+        assert_eq!(up.servers.len(), 1);
+        assert_eq!(up.servers[0].address, "10.0.0.1:80");
+        assert_eq!(up.servers[0].resolve, true);
+
+        // Assert Egress Upstreams
+        assert_eq!(routing_data.egress_upstreams.len(), 1);
+        let eup = &routing_data.egress_upstreams[0];
+        assert_eq!(eup.name, "egress_up_1");
+        assert_eq!(eup.lb_policy, "least_conn");
+        assert_eq!(eup.servers.len(), 1);
+        assert_eq!(eup.servers[0].address, "20.0.0.1:443");
+        assert_eq!(eup.servers[0].resolve, false);
+
+        // Assert Egress Vhost Rules
+        assert_eq!(routing_data.egress_vhost_rules.len(), 1);
+        let erule = &routing_data.egress_vhost_rules[0];
+        assert_eq!(erule.match_host, "example.com");
+        assert_eq!(erule.action_upstream, "egress_up_1");
     }
 }

--- a/tunnel-store/src/sqlite.rs
+++ b/tunnel-store/src/sqlite.rs
@@ -2,8 +2,8 @@ use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use sqlx::sqlite::{SqlitePool, SqlitePoolOptions};
 use sqlx::Row;
-use tunnel_lib::{ClientStatus, TokenStatus};
 use tracing::{info, warn};
+use tunnel_lib::{ClientStatus, TokenStatus};
 pub async fn open_sqlite_pool(database_url: &str, max_connections: u32) -> Result<SqlitePool> {
     if let Some(path) = database_url
         .strip_prefix("sqlite://")
@@ -139,11 +139,7 @@ impl AuthStore for SqliteAuthStore {
                     .ok_or_else(|| AuthError::Internal(anyhow!("invalid client status")))?;
                 let token_status = TokenStatus::parse(row.get::<&str, _>("token_status"))
                     .ok_or_else(|| AuthError::Internal(anyhow!("invalid token status")))?;
-                matched = Some((
-                    row.get("client_name"),
-                    client_status,
-                    token_status,
-                ));
+                matched = Some((row.get("client_name"), client_status, token_status));
             }
         }
         let (client_group, client_status, token_status) = match matched {

--- a/tunnel-store/src/sqlite_rules.rs
+++ b/tunnel-store/src/sqlite_rules.rs
@@ -168,7 +168,8 @@ impl SqliteRuleStore {
             .iter()
             .map(|listener| (listener.port, listener))
             .collect();
-        let desired_ports: HashSet<u16> = desired.ingress_listeners.iter().map(|l| l.port).collect();
+        let desired_ports: HashSet<u16> =
+            desired.ingress_listeners.iter().map(|l| l.port).collect();
         let delete_ports = current
             .ingress_listeners
             .iter()
@@ -180,10 +181,8 @@ impl SqliteRuleStore {
             .iter()
             .cloned()
             .map(|listener| {
-                let delete_vhosts = match (
-                    current_listener_map.get(&listener.port),
-                    &listener.mode,
-                ) {
+                let delete_vhosts = match (current_listener_map.get(&listener.port), &listener.mode)
+                {
                     (Some(existing), IngressListenerMode::Http { vhost }) => {
                         let desired_hosts: HashSet<&str> =
                             vhost.iter().map(|rule| rule.match_host.as_str()).collect();
@@ -210,8 +209,11 @@ impl SqliteRuleStore {
             .iter()
             .map(|group| (group.group_id.as_str(), group))
             .collect();
-        let desired_group_ids: HashSet<&str> =
-            desired.client_groups.iter().map(|group| group.group_id.as_str()).collect();
+        let desired_group_ids: HashSet<&str> = desired
+            .client_groups
+            .iter()
+            .map(|group| group.group_id.as_str())
+            .collect();
         let delete_groups = current
             .client_groups
             .iter()
@@ -224,8 +226,11 @@ impl SqliteRuleStore {
             .cloned()
             .map(|group| {
                 let existing_group = current_group_map.get(group.group_id.as_str()).copied();
-                let desired_upstream_names: HashSet<&str> =
-                    group.upstreams.iter().map(|upstream| upstream.name.as_str()).collect();
+                let desired_upstream_names: HashSet<&str> = group
+                    .upstreams
+                    .iter()
+                    .map(|upstream| upstream.name.as_str())
+                    .collect();
                 let delete_upstreams = existing_group
                     .map(|existing| {
                         existing
@@ -561,9 +566,10 @@ impl RuleStore for SqliteRuleStore {
             let l = &listener_plan.listener;
             let (mode, tcp_group, tcp_proxy) = match &l.mode {
                 IngressListenerMode::Http { .. } => ("http", None, None),
-                IngressListenerMode::Tcp { group_id, proxy_name } => {
-                    ("tcp", Some(group_id.as_str()), Some(proxy_name.as_str()))
-                }
+                IngressListenerMode::Tcp {
+                    group_id,
+                    proxy_name,
+                } => ("tcp", Some(group_id.as_str()), Some(proxy_name.as_str())),
             };
             sqlx::query(
                 "INSERT INTO ingress_listeners (port, mode, tcp_group, tcp_proxy)
@@ -629,11 +635,11 @@ impl RuleStore for SqliteRuleStore {
                  ON CONFLICT(group_id) DO UPDATE SET
                      config_version = excluded.config_version",
             )
-                .bind(&g.group_id)
-                .bind(&g.config_version)
-                .execute(&mut *tx)
-                .await
-                .context("upsert client group")?;
+            .bind(&g.group_id)
+            .bind(&g.config_version)
+            .execute(&mut *tx)
+            .await
+            .context("upsert client group")?;
             for upstream_name in &group_plan.delete_upstreams {
                 sqlx::query("DELETE FROM client_upstreams WHERE group_id = ? AND name = ?")
                     .bind(&g.group_id)
@@ -661,11 +667,11 @@ impl RuleStore for SqliteRuleStore {
                     sqlx::query(
                         "DELETE FROM client_upstream_servers WHERE upstream_id = ? AND address = ?",
                     )
-                        .bind(uid)
-                        .bind(address)
-                        .execute(&mut *tx)
-                        .await
-                        .context("delete stale client upstream server")?;
+                    .bind(uid)
+                    .bind(address)
+                    .execute(&mut *tx)
+                    .await
+                    .context("delete stale client upstream server")?;
                 }
                 for s in &u.servers {
                     sqlx::query(
@@ -707,11 +713,11 @@ impl RuleStore for SqliteRuleStore {
                 sqlx::query(
                     "DELETE FROM egress_upstream_servers WHERE upstream_id = ? AND address = ?",
                 )
-                    .bind(uid)
-                    .bind(address)
-                    .execute(&mut *tx)
-                    .await
-                    .context("delete stale egress server")?;
+                .bind(uid)
+                .bind(address)
+                .execute(&mut *tx)
+                .await
+                .context("delete stale egress server")?;
             }
             for s in &u.servers {
                 sqlx::query(
@@ -721,10 +727,10 @@ impl RuleStore for SqliteRuleStore {
                 )
                 .bind(uid)
                 .bind(&s.address)
-                    .bind(s.resolve as i64)
-                    .execute(&mut *tx)
-                    .await
-                    .context("insert egress server")?;
+                .bind(s.resolve as i64)
+                .execute(&mut *tx)
+                .await
+                .context("insert egress server")?;
             }
         }
         for match_host in plan.egress.delete_vhosts {

--- a/tunnel-store/src/traits.rs
+++ b/tunnel-store/src/traits.rs
@@ -16,10 +16,12 @@ fn mask_token_in_str(s: &str) -> String {
     let chars: Vec<char> = s.chars().collect();
     let mut i = 0;
     while i < chars.len() {
-        if i + 3 <= chars.len() && chars[i] == 'd' && chars[i+1] == 't' && chars[i+2] == '_' {
+        if i + 3 <= chars.len() && chars[i] == 'd' && chars[i + 1] == 't' && chars[i + 2] == '_' {
             let start = i;
             i += 3;
-            while i < chars.len() && (chars[i].is_ascii_alphanumeric() || chars[i] == '-' || chars[i] == '_') {
+            while i < chars.len()
+                && (chars[i].is_ascii_alphanumeric() || chars[i] == '-' || chars[i] == '_')
+            {
                 i += 1;
             }
             let token_len = i - start;


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the lack of unit testing for `routing_data_from_server_config` in `tunnel-store/src/server_config.rs`.

📊 **Coverage:** What scenarios are now tested
1. Handled empty configurations correctly.
2. Verified fully populated configurations mapping to `RoutingData`, including:
   - HTTP and TCP Ingress Listeners (and verifying that their `.id` defaults to `0`)
   - Client Groups (with client upstreams)
   - Egress Upstreams
   - Egress Vhost Rules

✨ **Result:** The improvement in test coverage
Two comprehensive unit tests have been added to prevent regressions when mapping `ServerConfigFile` to `RoutingData`. All tests are integrated correctly via a `#[cfg(test)]` block.

---
*PR created automatically by Jules for task [10002920255967343513](https://jules.google.com/task/10002920255967343513) started by @locustbaby*